### PR TITLE
Run simulation with a large data set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 target
 .bsp
+.DS_Store
 
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml

--- a/data/jobs_579.json
+++ b/data/jobs_579.json
@@ -1,579 +1,581 @@
-{"account_id":10730,"name":"query:0123/job_id:1912004","created_time":1687219221,"start_time":1687219221,"finished_time":1687219230,"cpu":926,"memory":0.033250387758016586}
-{"account_id":10730,"name":"query:0123/job_id:1925601","created_time":1687219605,"start_time":1687219605,"finished_time":1687219609,"cpu":94,"memory":0.002556886523962021}
-{"account_id":10730,"name":"query:0123/job_id:1931905","created_time":1687221543,"start_time":1687221543,"finished_time":1687221546,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1880528","created_time":1687221153,"start_time":1687221153,"finished_time":1687221154,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1889142","created_time":1687221911,"start_time":1687221911,"finished_time":1687221913,"cpu":0,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1948835","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1908991","created_time":1687221662,"start_time":1687221662,"finished_time":1687221663,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1938420","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":26,"memory":5.681067705154419e-7}
-{"account_id":10730,"name":"query:0123/job_id:1937417","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1907392","created_time":1687222233,"start_time":1687222234,"finished_time":1687222238,"cpu":3200,"memory":0.21290632057935}
-{"account_id":10730,"name":"query:0123/job_id:1888958","created_time":1687221673,"start_time":1687221673,"finished_time":1687221686,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1891839","created_time":1687221562,"start_time":1687221562,"finished_time":1687221565,"cpu":98,"memory":0.009178344160318375}
-{"account_id":10730,"name":"query:0123/job_id:1947110","created_time":1687222330,"start_time":1687222330,"finished_time":1687222332,"cpu":28,"memory":0.0002629132941365242}
-{"account_id":10730,"name":"query:0123/job_id:1870285","created_time":1687222063,"start_time":1687222063,"finished_time":1687222066,"cpu":140,"memory":0.00003091059625148773}
-{"account_id":10730,"name":"query:0123/job_id:1866013","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":1398,"memory":0.03518072981387377}
-{"account_id":10730,"name":"query:0123/job_id:1888131","created_time":1687221155,"start_time":1687221156,"finished_time":1687221160,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1926789","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":974,"memory":0.03765729535371065}
-{"account_id":10730,"name":"query:0123/job_id:1921568","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":60,"memory":0.0005164733156561852}
-{"account_id":10730,"name":"query:0123/job_id:1901172","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":27,"memory":3.4086406230926514e-7}
-{"account_id":10730,"name":"query:0123/job_id:1914114","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":34,"memory":0.0000012200325727462769}
-{"account_id":10730,"name":"query:0123/job_id:1898269","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000011362135410308838}
-{"account_id":10730,"name":"query:0123/job_id:1887999","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1892536","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":896,"memory":0.0025287531316280365}
-{"account_id":10730,"name":"query:0123/job_id:1948422","created_time":1687221342,"start_time":1687221342,"finished_time":1687221345,"cpu":15,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1901357","created_time":1687221342,"start_time":1687221342,"finished_time":1687221345,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1903606","created_time":1687221401,"start_time":1687221401,"finished_time":1687221411,"cpu":74629,"memory":3.5813009943813086}
-{"account_id":10730,"name":"query:0123/job_id:1896504","created_time":1687222224,"start_time":1687222224,"finished_time":1687222228,"cpu":1655,"memory":0.0606548385694623}
-{"account_id":10730,"name":"query:0123/job_id:1896401","created_time":1687220598,"start_time":1687220598,"finished_time":1687220605,"cpu":24817,"memory":0.000926673412322998}
-{"account_id":10730,"name":"query:0123/job_id:1926387","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1939729","created_time":1687222003,"start_time":1687222003,"finished_time":1687222005,"cpu":93,"memory":0.00010114442557096481}
-{"account_id":10730,"name":"query:0123/job_id:1932968","created_time":1687221366,"start_time":1687221366,"finished_time":1687221374,"cpu":2,"memory":0.000002236105501651764}
-{"account_id":10730,"name":"query:0123/job_id:1951194","created_time":1687222128,"start_time":1687222128,"finished_time":1687222138,"cpu":55493,"memory":2.2616777988150716}
-{"account_id":10730,"name":"query:0123/job_id:1942980","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":63,"memory":0.0003394652158021927}
-{"account_id":10730,"name":"query:0123/job_id:1881222","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":24,"memory":8.521601557731628e-7}
-{"account_id":10730,"name":"query:0123/job_id:1912566","created_time":1687219506,"start_time":1687219506,"finished_time":1687219509,"cpu":12,"memory":0.000009562820196151733}
-{"account_id":10730,"name":"query:0123/job_id:1887709","created_time":1687220719,"start_time":1687220720,"finished_time":1687220724,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1920382","created_time":1687219554,"start_time":1687219554,"finished_time":1687219556,"cpu":3,"memory":2.5331974029541016e-7}
-{"account_id":10730,"name":"query:0123/job_id:1902106","created_time":1687221941,"start_time":1687221941,"finished_time":1687221942,"cpu":1,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1901653","created_time":1687219442,"start_time":1687219442,"finished_time":1687219447,"cpu":144,"memory":0.00036424770951271057}
-{"account_id":10730,"name":"query:0123/job_id:1877408","created_time":1687219507,"start_time":1687219507,"finished_time":1687219513,"cpu":1,"memory":0.0000011064112186431885}
-{"account_id":10730,"name":"query:0123/job_id:1942629","created_time":1687219428,"start_time":1687219428,"finished_time":1687219436,"cpu":140,"memory":0.0002106623724102974}
-{"account_id":10730,"name":"query:0123/job_id:1935066","created_time":1687221413,"start_time":1687221413,"finished_time":1687221416,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1922976","created_time":1687220143,"start_time":1687220143,"finished_time":1687220508,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1854783","created_time":1687220065,"start_time":1687220065,"finished_time":1687220139,"cpu":1252851,"memory":17.947971625253558}
-{"account_id":10730,"name":"query:0123/job_id:1901449","created_time":1687222287,"start_time":1687222287,"finished_time":1687222294,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1868286","created_time":1687222287,"start_time":1687222287,"finished_time":1687222294,"cpu":40214,"memory":2.2588757760822773}
-{"account_id":10730,"name":"query:0123/job_id:1907493","created_time":1687222477,"start_time":1687222477,"finished_time":1687222479,"cpu":150771,"memory":0.002548140473663807}
-{"account_id":10730,"name":"query:0123/job_id:1902108","created_time":1687221586,"start_time":1687221586,"finished_time":1687221686,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1869923","created_time":1687221543,"start_time":1687221543,"finished_time":1687221546,"cpu":426,"memory":0.018877992406487465}
-{"account_id":10730,"name":"query:0123/job_id:1937874","created_time":1687222512,"start_time":1687222512,"finished_time":1687222514,"cpu":119406,"memory":0.000977061688899994}
-{"account_id":10730,"name":"query:0123/job_id:1939232","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":56,"memory":0.0006288588047027588}
-{"account_id":10730,"name":"query:0123/job_id:1857943","created_time":1687221469,"start_time":1687221469,"finished_time":1687221470,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1947090","created_time":1687221009,"start_time":1687221009,"finished_time":1687221016,"cpu":877,"memory":0.029430674389004707}
-{"account_id":10730,"name":"query:0123/job_id:1878674","created_time":1687221414,"start_time":1687221414,"finished_time":1687221426,"cpu":300010,"memory":1.5748306103050709}
-{"account_id":10730,"name":"query:0123/job_id:1893029","created_time":1687221652,"start_time":1687221652,"finished_time":1687221663,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1903517","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":284,"memory":0.00008616875857114792}
-{"account_id":10730,"name":"query:0123/job_id:1945417","created_time":1687221638,"start_time":1687221638,"finished_time":1687221639,"cpu":0,"memory":2.598389983177185e-7}
-{"account_id":10730,"name":"query:0123/job_id:1903809","created_time":1687220961,"start_time":1687220961,"finished_time":1687220964,"cpu":128,"memory":0.00003502052277326584}
-{"account_id":10730,"name":"query:0123/job_id:1870659","created_time":1687221396,"start_time":1687221396,"finished_time":1687221398,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1931916","created_time":1687221432,"start_time":1687221432,"finished_time":1687221436,"cpu":8412,"memory":0.31992046628147364}
-{"account_id":10730,"name":"query:0123/job_id:1893291","created_time":1687221137,"start_time":1687221137,"finished_time":1687221139,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1881715","created_time":1687222064,"start_time":1687222064,"finished_time":1687222066,"cpu":31,"memory":0.000012818723917007446}
-{"account_id":10730,"name":"query:0123/job_id:1916625","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1906892","created_time":1687221458,"start_time":1687221458,"finished_time":1687221460,"cpu":43,"memory":0.00002164021134376526}
-{"account_id":10730,"name":"query:0123/job_id:1856958","created_time":1687221394,"start_time":1687221394,"finished_time":1687221396,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1897372","created_time":1687219490,"start_time":1687219491,"finished_time":1687219493,"cpu":9,"memory":0.0000046407803893089294}
-{"account_id":10730,"name":"query:0123/job_id:1874402","created_time":1687220064,"start_time":1687220064,"finished_time":1687220096,"cpu":96621,"memory":9.694063430652022}
-{"account_id":10730,"name":"query:0123/job_id:1954135","created_time":1687219480,"start_time":1687219480,"finished_time":1687219484,"cpu":23,"memory":7.348135113716125e-7}
-{"account_id":10730,"name":"query:0123/job_id:1913260","created_time":1687221920,"start_time":1687221920,"finished_time":1687222037,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1922185","created_time":1687221903,"start_time":1687221903,"finished_time":1687221906,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1886433","created_time":1687222002,"start_time":1687222002,"finished_time":1687222006,"cpu":1745,"memory":0.0030351150780916214}
-{"account_id":10730,"name":"query:0123/job_id:1913742","created_time":1687219592,"start_time":1687219592,"finished_time":1687219594,"cpu":6,"memory":4.470348358154297e-7}
-{"account_id":10730,"name":"query:0123/job_id:1885859","created_time":1687221993,"start_time":1687221994,"finished_time":1687221997,"cpu":190,"memory":0.010221323929727077}
-{"account_id":10730,"name":"query:0123/job_id:1928138","created_time":1687222036,"start_time":1687222036,"finished_time":1687222040,"cpu":63,"memory":0.000019278377294540405}
-{"account_id":10730,"name":"query:0123/job_id:1922489","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1858862","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":751461,"memory":7.0592819061130285}
-{"account_id":10730,"name":"query:0123/job_id:1913007","created_time":1687219479,"start_time":1687219479,"finished_time":1687219483,"cpu":1,"memory":0.000008128583431243896}
-{"account_id":10730,"name":"query:0123/job_id:1862761","created_time":1687219580,"start_time":1687219580,"finished_time":1687219580,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1913479","created_time":1687222044,"start_time":1687222044,"finished_time":1687222053,"cpu":69413,"memory":0.0034308386966586113}
-{"account_id":10730,"name":"query:0123/job_id:1931906","created_time":1687221948,"start_time":1687221948,"finished_time":1687221949,"cpu":0,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1928862","created_time":1687222078,"start_time":1687222079,"finished_time":1687222101,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1863952","created_time":1687222124,"start_time":1687222124,"finished_time":1687222124,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1870288","created_time":1687219593,"start_time":1687219593,"finished_time":1687219593,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1854445","created_time":1687219766,"start_time":1687219766,"finished_time":1687219768,"cpu":2,"memory":2.2351741790771484e-8}
-{"account_id":10730,"name":"query:0123/job_id:1919714","created_time":1687221920,"start_time":1687221920,"finished_time":1687222037,"cpu":3295085,"memory":122.1370611274615}
-{"account_id":10730,"name":"query:0123/job_id:1859251","created_time":1687219719,"start_time":1687219719,"finished_time":1687219797,"cpu":407112,"memory":0.8181027173995972}
-{"account_id":10730,"name":"query:0123/job_id:1932390","created_time":1687222124,"start_time":1687222124,"finished_time":1687222126,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1864350","created_time":1687219425,"start_time":1687219425,"finished_time":1687219434,"cpu":139,"memory":0.00006481260061264038}
-{"account_id":10730,"name":"query:0123/job_id:1912121","created_time":1687221338,"start_time":1687221338,"finished_time":1687221352,"cpu":167742,"memory":1.258029531687498}
-{"account_id":10730,"name":"query:0123/job_id:1951779","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1946539","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":28,"memory":0.000001193024218082428}
-{"account_id":10730,"name":"query:0123/job_id:1862916","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":31,"memory":0.00001786835491657257}
-{"account_id":10730,"name":"query:0123/job_id:1931456","created_time":1687219283,"start_time":1687219283,"finished_time":1687219284,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1895437","created_time":1687220206,"start_time":1687220206,"finished_time":1687220210,"cpu":1948,"memory":0.0730581572279334}
-{"account_id":10730,"name":"query:0123/job_id:1864718","created_time":1687219245,"start_time":1687219245,"finished_time":1687219251,"cpu":124,"memory":0.00005942396819591522}
-{"account_id":10730,"name":"query:0123/job_id:1870346","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1857902","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":1494,"memory":0.035645054653286934}
-{"account_id":10730,"name":"query:0123/job_id:1948603","created_time":1687219279,"start_time":1687219279,"finished_time":1687219280,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1930828","created_time":1687220315,"start_time":1687220315,"finished_time":1687220316,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1871634","created_time":1687220143,"start_time":1687220143,"finished_time":1687220508,"cpu":6672697,"memory":642.4476086022332}
-{"account_id":10730,"name":"query:0123/job_id:1953149","created_time":1687221595,"start_time":1687221595,"finished_time":1687221781,"cpu":6772887,"memory":520.4691209448501}
-{"account_id":10730,"name":"query:0123/job_id:1914861","created_time":1687219366,"start_time":1687219366,"finished_time":1687219539,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1909009","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1860471","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":35,"memory":6.966292858123779e-7}
-{"account_id":10730,"name":"query:0123/job_id:1859264","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1952116","created_time":1687221476,"start_time":1687221476,"finished_time":1687221485,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1876283","created_time":1687221566,"start_time":1687221566,"finished_time":1687221594,"cpu":84464,"memory":0.4318245854228735}
-{"account_id":10730,"name":"query:0123/job_id:1857237","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":63,"memory":0.00033929944038391113}
-{"account_id":10730,"name":"query:0123/job_id:1910057","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1885038","created_time":1687221700,"start_time":1687221700,"finished_time":1687221717,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1933425","created_time":1687221180,"start_time":1687221180,"finished_time":1687221193,"cpu":141502,"memory":0.3628418678417802}
-{"account_id":10730,"name":"query:0123/job_id:1854545","created_time":1687219223,"start_time":1687219224,"finished_time":1687219229,"cpu":499,"memory":0.018095098435878754}
-{"account_id":10730,"name":"query:0123/job_id:1950861","created_time":1687220165,"start_time":1687220165,"finished_time":1687220172,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1856495","created_time":1687221713,"start_time":1687221713,"finished_time":1687221713,"cpu":23,"memory":0.000008493661880493164}
-{"account_id":10730,"name":"query:0123/job_id:1908744","created_time":1687221207,"start_time":1687221207,"finished_time":1687221221,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1930949","created_time":1687219270,"start_time":1687219270,"finished_time":1687219271,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1896857","created_time":1687221726,"start_time":1687221726,"finished_time":1687221746,"cpu":345782,"memory":15.866151478141546}
-{"account_id":10730,"name":"query:0123/job_id:1857024","created_time":1687219239,"start_time":1687219239,"finished_time":1687219343,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1934669","created_time":1687221259,"start_time":1687221259,"finished_time":1687221272,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1923121","created_time":1687221166,"start_time":1687221166,"finished_time":1687221169,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1900792","created_time":1687220337,"start_time":1687220337,"finished_time":1687220511,"cpu":1295136,"memory":7.5980514250695705}
-{"account_id":10730,"name":"query:0123/job_id:1942479","created_time":1687221166,"start_time":1687221166,"finished_time":1687221169,"cpu":1641,"memory":0.012543651275336742}
-{"account_id":10730,"name":"query:0123/job_id:1892038","created_time":1687220337,"start_time":1687220337,"finished_time":1687220511,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1942067","created_time":1687221794,"start_time":1687221794,"finished_time":1687221797,"cpu":17,"memory":0.000005797483026981354}
-{"account_id":10730,"name":"query:0123/job_id:1857482","created_time":1687221180,"start_time":1687221181,"finished_time":1687221197,"cpu":142087,"memory":0.38752821646630764}
-{"account_id":10730,"name":"query:0123/job_id:1918293","created_time":1687220972,"start_time":1687220972,"finished_time":1687220974,"cpu":153,"memory":0.00003400444984436035}
-{"account_id":10730,"name":"query:0123/job_id:1952573","created_time":1687222564,"start_time":1687222564,"finished_time":1687222564,"cpu":58,"memory":0.00002615712583065033}
-{"account_id":10730,"name":"query:0123/job_id:1946168","created_time":1687221198,"start_time":1687221198,"finished_time":1687221216,"cpu":303601,"memory":1.5264784283936024}
-{"account_id":10730,"name":"query:0123/job_id:1875129","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":22,"memory":0.0000011362135410308838}
-{"account_id":10730,"name":"query:0123/job_id:1921946","created_time":1687220058,"start_time":1687220058,"finished_time":1687220060,"cpu":31,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1891556","created_time":1687222673,"start_time":1687222673,"finished_time":1687222674,"cpu":131,"memory":0.005979131907224655}
-{"account_id":10730,"name":"query:0123/job_id:1910429","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1892404","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1943290","created_time":1687221678,"start_time":1687221678,"finished_time":1687221690,"cpu":338741,"memory":15.848402245901525}
-{"account_id":10730,"name":"query:0123/job_id:1893116","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":713,"memory":0.00006329640746116638}
-{"account_id":10730,"name":"query:0123/job_id:1941804","created_time":1687219803,"start_time":1687219803,"finished_time":1687219809,"cpu":479,"memory":0.04549068585038185}
-{"account_id":10730,"name":"query:0123/job_id:1916067","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":2672,"memory":0.20393055025488138}
-{"account_id":10730,"name":"query:0123/job_id:1880706","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":3084,"memory":0.13397594913840294}
-{"account_id":10730,"name":"query:0123/job_id:1923026","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":188,"memory":0.003415885381400585}
-{"account_id":10730,"name":"query:0123/job_id:1883921","created_time":1687221064,"start_time":1687221064,"finished_time":1687221066,"cpu":1794,"memory":0.02219575271010399}
-{"account_id":10730,"name":"query:0123/job_id:1940411","created_time":1687219281,"start_time":1687219281,"finished_time":1687219282,"cpu":0,"memory":2.9616057872772217e-7}
-{"account_id":10730,"name":"query:0123/job_id:1909408","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":12147,"memory":0.02192867361009121}
-{"account_id":10730,"name":"query:0123/job_id:1863477","created_time":1687221551,"start_time":1687221551,"finished_time":1687221554,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1877423","created_time":1687221812,"start_time":1687221812,"finished_time":1687221814,"cpu":0,"memory":1.8067657947540283e-7}
-{"account_id":10730,"name":"query:0123/job_id:1870782","created_time":1687221011,"start_time":1687221011,"finished_time":1687221016,"cpu":465,"memory":0.008985631167888641}
-{"account_id":10730,"name":"query:0123/job_id:1904356","created_time":1687220327,"start_time":1687220327,"finished_time":1687220328,"cpu":3,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1936714","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":68,"memory":0.00031025707721710205}
-{"account_id":10730,"name":"query:0123/job_id:1860554","created_time":1687220286,"start_time":1687220286,"finished_time":1687220287,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1909232","created_time":1687220276,"start_time":1687220277,"finished_time":1687220282,"cpu":1749,"memory":0.09938544686883688}
-{"account_id":10730,"name":"query:0123/job_id:1899682","created_time":1687221307,"start_time":1687221307,"finished_time":1687221312,"cpu":371,"memory":0.020730093121528625}
-{"account_id":10730,"name":"query:0123/job_id:1902228","created_time":1687221700,"start_time":1687221700,"finished_time":1687221717,"cpu":196451,"memory":14.283711779862642}
-{"account_id":10730,"name":"query:0123/job_id:1906768","created_time":1687222182,"start_time":1687222182,"finished_time":1687222192,"cpu":78262,"memory":3.15274715423584}
-{"account_id":10730,"name":"query:0123/job_id:1952622","created_time":1687221243,"start_time":1687221243,"finished_time":1687221246,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1944321","created_time":1687219932,"start_time":1687219932,"finished_time":1687219932,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1947475","created_time":1687221784,"start_time":1687221784,"finished_time":1687221788,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1890579","created_time":1687222769,"start_time":1687222769,"finished_time":1687222770,"cpu":1,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1906299","created_time":1687221149,"start_time":1687221149,"finished_time":1687221150,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1893809","created_time":1687221576,"start_time":1687221576,"finished_time":1687221580,"cpu":468,"memory":0.018266317434608936}
-{"account_id":10730,"name":"query:0123/job_id:1887634","created_time":1687221211,"start_time":1687221211,"finished_time":1687221219,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1904857","created_time":1687222260,"start_time":1687222260,"finished_time":1687224138,"cpu":15020694,"memory":419.7829972356558}
-{"account_id":10730,"name":"query:0123/job_id:1948795","created_time":1687221227,"start_time":1687221227,"finished_time":1687221900,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1863378","created_time":1687221227,"start_time":1687221227,"finished_time":1687221900,"cpu":56539252,"memory":0.6547873811796308}
-{"account_id":10730,"name":"query:0123/job_id:1894057","created_time":1687219270,"start_time":1687219270,"finished_time":1687219273,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1910061","created_time":1687220181,"start_time":1687220181,"finished_time":1687220189,"cpu":13937,"memory":0.8185670180246234}
-{"account_id":10730,"name":"query:0123/job_id:1893140","created_time":1687220165,"start_time":1687220165,"finished_time":1687220172,"cpu":8561,"memory":0.4186299592256546}
-{"account_id":10730,"name":"query:0123/job_id:1953233","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1911856","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":26,"memory":5.112960934638977e-7}
-{"account_id":10730,"name":"query:0123/job_id:1928560","created_time":1687221419,"start_time":1687221419,"finished_time":1687221422,"cpu":194,"memory":0.01991942524909973}
-{"account_id":10730,"name":"query:0123/job_id:1917536","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":58,"memory":0.0006933510303497314}
-{"account_id":10730,"name":"query:0123/job_id:1859468","created_time":1687221673,"start_time":1687221673,"finished_time":1687221686,"cpu":168257,"memory":0.7430028775706887}
-{"account_id":10730,"name":"query:0123/job_id:1896004","created_time":1687221298,"start_time":1687221298,"finished_time":1687221301,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1951253","created_time":1687221272,"start_time":1687221272,"finished_time":1687221286,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879518","created_time":1687221564,"start_time":1687221564,"finished_time":1687221569,"cpu":2601,"memory":0.08853498939424753}
-{"account_id":10730,"name":"query:0123/job_id:1950539","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":8,"memory":0.000001325272023677826}
-{"account_id":10730,"name":"query:0123/job_id:1864507","created_time":1687221843,"start_time":1687221843,"finished_time":1687221844,"cpu":0,"memory":1.8067657947540283e-7}
-{"account_id":10730,"name":"query:0123/job_id:1858299","created_time":1687221701,"start_time":1687221701,"finished_time":1687221716,"cpu":53425,"memory":4.135097972117364}
-{"account_id":10730,"name":"query:0123/job_id:1902214","created_time":1687221198,"start_time":1687221198,"finished_time":1687221215,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1948154","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":27,"memory":0.0000010225921869277954}
-{"account_id":10730,"name":"query:0123/job_id:1921846","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":59,"memory":0.0005015730857849121}
-{"account_id":10730,"name":"query:0123/job_id:1902695","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":31,"memory":0.0000013867393136024475}
-{"account_id":10730,"name":"query:0123/job_id:1888486","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":18,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1950008","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":28,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1929116","created_time":1687221198,"start_time":1687221198,"finished_time":1687221216,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879948","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000013634562492370605}
-{"account_id":10730,"name":"query:0123/job_id:1895052","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":112,"memory":0.0036832140758633614}
-{"account_id":10730,"name":"query:0123/job_id:1873757","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":48,"memory":0.000010829418897628784}
-{"account_id":10730,"name":"query:0123/job_id:1945201","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1940546","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":1315,"memory":0.07021963689476252}
-{"account_id":10730,"name":"query:0123/job_id:1889682","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1942594","created_time":1687220147,"start_time":1687220147,"finished_time":1687220151,"cpu":1024,"memory":0.1362330112606287}
-{"account_id":10730,"name":"query:0123/job_id:1867825","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":2098,"memory":0.021414509043097496}
-{"account_id":10730,"name":"query:0123/job_id:1904626","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":1898,"memory":0.03817306272685528}
-{"account_id":10730,"name":"query:0123/job_id:1912913","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":5957,"memory":0.04042312130331993}
-{"account_id":10730,"name":"query:0123/job_id:1855990","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":1598,"memory":0.03528424259275198}
-{"account_id":10730,"name":"query:0123/job_id:1948134","created_time":1687221752,"start_time":1687221752,"finished_time":1687221762,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1946338","created_time":1687221752,"start_time":1687221752,"finished_time":1687221762,"cpu":40511,"memory":0.4329881453886628}
-{"account_id":10730,"name":"query:0123/job_id:1906339","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":5535,"memory":0.01947631500661373}
-{"account_id":10730,"name":"query:0123/job_id:1910718","created_time":1687219602,"start_time":1687219602,"finished_time":1687219603,"cpu":6,"memory":1.51805579662323e-7}
-{"account_id":10730,"name":"query:0123/job_id:1902998","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1935454","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1890767","created_time":1687220045,"start_time":1687220045,"finished_time":1687220049,"cpu":1787,"memory":0.03971358947455883}
-{"account_id":10730,"name":"query:0123/job_id:1876947","created_time":1687219282,"start_time":1687219282,"finished_time":1687219282,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1951482","created_time":1687219390,"start_time":1687219390,"finished_time":1687219390,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1864434","created_time":1687221784,"start_time":1687221784,"finished_time":1687221788,"cpu":206,"memory":0.04022339545190334}
-{"account_id":10730,"name":"query:0123/job_id:1938188","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":33,"memory":0.0000010365620255470276}
-{"account_id":10730,"name":"query:0123/job_id:1943010","created_time":1687221756,"start_time":1687221756,"finished_time":1687221776,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1895516","created_time":1687221207,"start_time":1687221207,"finished_time":1687221221,"cpu":166350,"memory":0.635268528945744}
-{"account_id":10730,"name":"query:0123/job_id:1916059","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1908730","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":1527,"memory":0.03525341860949993}
-{"account_id":10730,"name":"query:0123/job_id:1941362","created_time":1687221211,"start_time":1687221211,"finished_time":1687221219,"cpu":21002,"memory":1.09300653077662}
-{"account_id":10730,"name":"query:0123/job_id:1925571","created_time":1687221701,"start_time":1687221701,"finished_time":1687221716,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1929307","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1895303","created_time":1687221756,"start_time":1687221756,"finished_time":1687221776,"cpu":195149,"memory":14.429218634031713}
-{"account_id":10730,"name":"query:0123/job_id:1879960","created_time":1687221773,"start_time":1687221773,"finished_time":1687221774,"cpu":2,"memory":2.812594175338745e-7}
-{"account_id":10730,"name":"query:0123/job_id:1879934","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":1847,"memory":0.03789173625409603}
-{"account_id":10730,"name":"query:0123/job_id:1894612","created_time":1687221366,"start_time":1687221366,"finished_time":1687221366,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1859386","created_time":1687219840,"start_time":1687219840,"finished_time":1687220117,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1923169","created_time":1687221198,"start_time":1687221198,"finished_time":1687221215,"cpu":169425,"memory":0.565388360992074}
-{"account_id":10730,"name":"query:0123/job_id:1876356","created_time":1687221450,"start_time":1687221450,"finished_time":1687221451,"cpu":2,"memory":0.0000028759241104125977}
-{"account_id":10730,"name":"query:0123/job_id:1920479","created_time":1687221272,"start_time":1687221272,"finished_time":1687221286,"cpu":166208,"memory":0.6223469125106931}
-{"account_id":10730,"name":"query:0123/job_id:1862812","created_time":1687221298,"start_time":1687221298,"finished_time":1687221301,"cpu":51,"memory":0.000019278377294540405}
-{"account_id":10730,"name":"query:0123/job_id:1934435","created_time":1687221436,"start_time":1687221437,"finished_time":1687221439,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1932540","created_time":1687221436,"start_time":1687221437,"finished_time":1687221439,"cpu":337,"memory":0.015073344111442566}
-{"account_id":10730,"name":"query:0123/job_id:1885991","created_time":1687221442,"start_time":1687221442,"finished_time":1687221444,"cpu":13,"memory":8.717179298400879e-7}
-{"account_id":10730,"name":"query:0123/job_id:1914361","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":31,"memory":0.000002259388566017151}
-{"account_id":10730,"name":"query:0123/job_id:1937301","created_time":1687219801,"start_time":1687219801,"finished_time":1687219804,"cpu":1,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1941185","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":19,"memory":0.000001817941665649414}
-{"account_id":10730,"name":"query:0123/job_id:1885158","created_time":1687221490,"start_time":1687221490,"finished_time":1687221521,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1906556","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":167483,"memory":4.3279227670282125}
-{"account_id":10730,"name":"query:0123/job_id:1951865","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":789177,"memory":14.888746425509453}
-{"account_id":10730,"name":"query:0123/job_id:1928153","created_time":1687221413,"start_time":1687221413,"finished_time":1687221416,"cpu":15,"memory":0.000001819804310798645}
-{"account_id":10730,"name":"query:0123/job_id:1872963","created_time":1687221157,"start_time":1687221157,"finished_time":1687221161,"cpu":2110,"memory":0.1509679052978754}
-{"account_id":10730,"name":"query:0123/job_id:1947016","created_time":1687221595,"start_time":1687221595,"finished_time":1687221781,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1921732","created_time":1687221772,"start_time":1687221772,"finished_time":1687221774,"cpu":126,"memory":0.00031345896422863007}
-{"account_id":10730,"name":"query:0123/job_id:1931520","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":2009,"memory":0.025191902182996273}
-{"account_id":10730,"name":"query:0123/job_id:1947298","created_time":1687221595,"start_time":1687221596,"finished_time":1687221604,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1952398","created_time":1687221459,"start_time":1687221459,"finished_time":1687221483,"cpu":529875,"memory":40.296030009165406}
-{"account_id":10730,"name":"query:0123/job_id:1919612","created_time":1687221459,"start_time":1687221459,"finished_time":1687221483,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1863259","created_time":1687221832,"start_time":1687221832,"finished_time":1687221833,"cpu":6,"memory":0.0000030938535928726196}
-{"account_id":10730,"name":"query:0123/job_id:1931591","created_time":1687221436,"start_time":1687221436,"finished_time":1687221438,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1878382","created_time":1687221551,"start_time":1687221551,"finished_time":1687221555,"cpu":32162,"memory":0.00627507921308279}
-{"account_id":10730,"name":"query:0123/job_id:1893028","created_time":1687220671,"start_time":1687220671,"finished_time":1687220679,"cpu":4786,"memory":0.20243860315531492}
-{"account_id":10730,"name":"query:0123/job_id:1938013","created_time":1687220048,"start_time":1687220048,"finished_time":1687220049,"cpu":98,"memory":0.000004218891263008118}
-{"account_id":10730,"name":"query:0123/job_id:1930687","created_time":1687219239,"start_time":1687219239,"finished_time":1687219343,"cpu":2368616,"memory":61.78435374144465}
-{"account_id":10730,"name":"query:0123/job_id:1937070","created_time":1687221311,"start_time":1687221311,"finished_time":1687221313,"cpu":16,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1894249","created_time":1687221259,"start_time":1687221259,"finished_time":1687221272,"cpu":297862,"memory":1.5671367589384317}
-{"account_id":10730,"name":"query:0123/job_id:1862176","created_time":1687221311,"start_time":1687221311,"finished_time":1687221313,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1878597","created_time":1687221802,"start_time":1687221802,"finished_time":1687221803,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1895733","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":999305,"memory":3.5917544178664684}
-{"account_id":10730,"name":"query:0123/job_id:1862368","created_time":1687218795,"start_time":1687218795,"finished_time":1687219213,"cpu":31001783,"memory":1562.2868827730417}
-{"account_id":10730,"name":"query:0123/job_id:1934931","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1944051","created_time":1687221832,"start_time":1687221832,"finished_time":1687221837,"cpu":2,"memory":0.0000022510066628456116}
-{"account_id":10730,"name":"query:0123/job_id:1856797","created_time":1687219283,"start_time":1687219283,"finished_time":1687219284,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1919389","created_time":1687220915,"start_time":1687220915,"finished_time":1687220922,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879667","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":1587,"memory":0.03553505148738623}
-{"account_id":10730,"name":"query:0123/job_id:1952779","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":59,"memory":0.0006197383627295494}
-{"account_id":10730,"name":"query:0123/job_id:1857716","created_time":1687221770,"start_time":1687221770,"finished_time":1687221771,"cpu":3,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1863028","created_time":1687221731,"start_time":1687221731,"finished_time":1687221735,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1915631","created_time":1687220962,"start_time":1687220962,"finished_time":1687220964,"cpu":148,"memory":0.00003062933683395386}
-{"account_id":10730,"name":"query:0123/job_id:1890204","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1886191","created_time":1687221801,"start_time":1687221801,"finished_time":1687221813,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1934081","created_time":1687220265,"start_time":1687220266,"finished_time":1687220271,"cpu":1450,"memory":0.19393836334347725}
-{"account_id":10730,"name":"query:0123/job_id:1952354","created_time":1687221366,"start_time":1687221366,"finished_time":1687221389,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1887129","created_time":1687220969,"start_time":1687220969,"finished_time":1687220972,"cpu":142,"memory":0.0003489600494503975}
-{"account_id":10730,"name":"query:0123/job_id:1895099","created_time":1687222148,"start_time":1687222148,"finished_time":1687222175,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1908424","created_time":1687221551,"start_time":1687221551,"finished_time":1687221554,"cpu":201,"memory":0.003810340538620949}
-{"account_id":10730,"name":"query:0123/job_id:1854526","created_time":1687221473,"start_time":1687221473,"finished_time":1687221475,"cpu":8,"memory":0.000004100613296031952}
-{"account_id":10730,"name":"query:0123/job_id:1884732","created_time":1687221278,"start_time":1687221278,"finished_time":1687221281,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1931881","created_time":1687221307,"start_time":1687221307,"finished_time":1687221312,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1887013","created_time":1687221243,"start_time":1687221243,"finished_time":1687221246,"cpu":16,"memory":0.000003050081431865692}
-{"account_id":10730,"name":"query:0123/job_id:1928755","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":1451,"memory":0.03482540510594845}
-{"account_id":10730,"name":"query:0123/job_id:1895201","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":1014401,"memory":3.7198743633925915}
-{"account_id":10730,"name":"query:0123/job_id:1935449","created_time":1687221642,"start_time":1687221642,"finished_time":1687221645,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1927570","created_time":1687221642,"start_time":1687221642,"finished_time":1687221645,"cpu":1058,"memory":0.004289193078875542}
-{"account_id":10730,"name":"query:0123/job_id:1948220","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1953929","created_time":1687221802,"start_time":1687221802,"finished_time":1687221803,"cpu":8,"memory":0.000004500150680541992}
-{"account_id":10730,"name":"query:0123/job_id:1896263","created_time":1687221054,"start_time":1687221054,"finished_time":1687221054,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1942657","created_time":1687220165,"start_time":1687220165,"finished_time":1687220165,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1920408","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":2016,"memory":0.052192116156220436}
-{"account_id":10730,"name":"query:0123/job_id:1918939","created_time":1687221772,"start_time":1687221772,"finished_time":1687221774,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1891522","created_time":1687220388,"start_time":1687220388,"finished_time":1687220390,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1941666","created_time":1687221336,"start_time":1687221336,"finished_time":1687221341,"cpu":11356,"memory":0.4637690931558609}
-{"account_id":10730,"name":"query:0123/job_id:1941482","created_time":1687221180,"start_time":1687221180,"finished_time":1687221193,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1873799","created_time":1687221300,"start_time":1687221300,"finished_time":1687221317,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1954036","created_time":1687220671,"start_time":1687220671,"finished_time":1687220679,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879778","created_time":1687221586,"start_time":1687221586,"finished_time":1687221686,"cpu":2629412,"memory":14.09130791388452}
-{"account_id":10730,"name":"query:0123/job_id:1911466","created_time":1687221739,"start_time":1687221739,"finished_time":1687221740,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1922206","created_time":1687221180,"start_time":1687221181,"finished_time":1687221197,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1931864","created_time":1687219764,"start_time":1687219764,"finished_time":1687219937,"cpu":4152084,"memory":231.26982422545552}
-{"account_id":10730,"name":"query:0123/job_id:1881333","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1895399","created_time":1687221794,"start_time":1687221794,"finished_time":1687221797,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1871964","created_time":1687221722,"start_time":1687221722,"finished_time":1687221724,"cpu":2,"memory":4.731118679046631e-7}
-{"account_id":10730,"name":"query:0123/job_id:1883348","created_time":1687221726,"start_time":1687221726,"finished_time":1687221746,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1909970","created_time":1687219250,"start_time":1687219250,"finished_time":1687219251,"cpu":5,"memory":0.0000010319054126739502}
-{"account_id":10730,"name":"query:0123/job_id:1942771","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":9040,"memory":0.5340307019650936}
-{"account_id":10730,"name":"query:0123/job_id:1873401","created_time":1687219956,"start_time":1687219957,"finished_time":1687220122,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1864331","created_time":1687220932,"start_time":1687220932,"finished_time":1687220940,"cpu":15383,"memory":0.7506414540112019}
-{"account_id":10730,"name":"query:0123/job_id:1934982","created_time":1687221781,"start_time":1687221781,"finished_time":1687221785,"cpu":35,"memory":0.000004235655069351196}
-{"account_id":10730,"name":"query:0123/job_id:1882129","created_time":1687221243,"start_time":1687221243,"finished_time":1687221256,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1894840","created_time":1687221570,"start_time":1687221570,"finished_time":1687221571,"cpu":43,"memory":0.000012252479791641235}
-{"account_id":10730,"name":"query:0123/job_id:1874005","created_time":1687221243,"start_time":1687221243,"finished_time":1687221256,"cpu":171289,"memory":0.6650124043226242}
-{"account_id":10730,"name":"query:0123/job_id:1862541","created_time":1687222148,"start_time":1687222148,"finished_time":1687222175,"cpu":65102,"memory":0.6362147992476821}
-{"account_id":10730,"name":"query:0123/job_id:1910345","created_time":1687219819,"start_time":1687219819,"finished_time":1687219822,"cpu":1599,"memory":0.001293383538722992}
-{"account_id":10730,"name":"query:0123/job_id:1893205","created_time":1687221163,"start_time":1687221163,"finished_time":1687221179,"cpu":252579,"memory":4.632825382053852}
-{"account_id":10730,"name":"query:0123/job_id:1952873","created_time":1687221445,"start_time":1687221445,"finished_time":1687221450,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1893202","created_time":1687221457,"start_time":1687221457,"finished_time":1687221457,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1922775","created_time":1687221611,"start_time":1687221612,"finished_time":1687221613,"cpu":14,"memory":0.0000016689300537109375}
-{"account_id":10730,"name":"query:0123/job_id:1893929","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":2046,"memory":0.08831286523491144}
-{"account_id":10730,"name":"query:0123/job_id:1941961","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1882230","created_time":1687221819,"start_time":1687221819,"finished_time":1687221827,"cpu":88,"memory":0.00024253875017166138}
-{"account_id":10730,"name":"query:0123/job_id:1905957","created_time":1687221167,"start_time":1687221167,"finished_time":1687221170,"cpu":1061,"memory":0.018153954297304153}
-{"account_id":10730,"name":"query:0123/job_id:1863291","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1893779","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1949795","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1900140","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1887370","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":55,"memory":0.00032454729080200195}
-{"account_id":10730,"name":"query:0123/job_id:1941695","created_time":1687221155,"start_time":1687221156,"finished_time":1687221160,"cpu":2411,"memory":0.13838768657296896}
-{"account_id":10730,"name":"query:0123/job_id:1945390","created_time":1687221801,"start_time":1687221801,"finished_time":1687221813,"cpu":40026,"memory":0.4121660841628909}
-{"account_id":10730,"name":"query:0123/job_id:1859308","created_time":1687219394,"start_time":1687219395,"finished_time":1687220980,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1927763","created_time":1687219220,"start_time":1687219220,"finished_time":1687219227,"cpu":180,"memory":0.00036745332181453705}
-{"account_id":10730,"name":"query:0123/job_id:1889368","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":6678,"memory":0.01642802730202675}
-{"account_id":10730,"name":"query:0123/job_id:1901523","created_time":1687220033,"start_time":1687220033,"finished_time":1687220037,"cpu":138,"memory":0.000020556151866912842}
-{"account_id":10730,"name":"query:0123/job_id:1943023","created_time":1687221278,"start_time":1687221278,"finished_time":1687221281,"cpu":18,"memory":0.000014452263712882996}
-{"account_id":10730,"name":"query:0123/job_id:1875845","created_time":1687220221,"start_time":1687220221,"finished_time":1687220262,"cpu":253529,"memory":0.2726001674309373}
-{"account_id":10730,"name":"query:0123/job_id:1877717","created_time":1687220197,"start_time":1687220198,"finished_time":1687220201,"cpu":1023,"memory":0.051492818631231785}
-{"account_id":10730,"name":"query:0123/job_id:1912682","created_time":1687222793,"start_time":1687222793,"finished_time":1687222793,"cpu":1,"memory":7.767230272293091e-7}
-{"account_id":10730,"name":"query:0123/job_id:1878419","created_time":1687220047,"start_time":1687220048,"finished_time":1687220051,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1916463","created_time":1687222497,"start_time":1687222497,"finished_time":1687222511,"cpu":889856,"memory":13.286113446578383}
-{"account_id":10730,"name":"query:0123/job_id:1945852","created_time":1687220046,"start_time":1687220046,"finished_time":1687220048,"cpu":57,"memory":9.844079613685608e-7}
-{"account_id":10730,"name":"query:0123/job_id:1912892","created_time":1687220690,"start_time":1687220690,"finished_time":1687220694,"cpu":1051,"memory":0.028402824886143208}
-{"account_id":10730,"name":"query:0123/job_id:1896902","created_time":1687220729,"start_time":1687220729,"finished_time":1687220741,"cpu":9175,"memory":0.4601225620135665}
-{"account_id":10730,"name":"query:0123/job_id:1901000","created_time":1687222096,"start_time":1687222096,"finished_time":1687222101,"cpu":42749,"memory":2.3187225153669715}
-{"account_id":10730,"name":"query:0123/job_id:1915416","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1927160","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1926382","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":1846,"memory":0.03563994821161032}
-{"account_id":10730,"name":"query:0123/job_id:1897488","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1856751","created_time":1687219605,"start_time":1687219605,"finished_time":1687219609,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1913212","created_time":1687222124,"start_time":1687222125,"finished_time":1687222126,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1903825","created_time":1687221913,"start_time":1687221913,"finished_time":1687221915,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1887001","created_time":1687221913,"start_time":1687221913,"finished_time":1687221915,"cpu":41,"memory":0.0000013373792171478271}
-{"account_id":10730,"name":"query:0123/job_id:1953145","created_time":1687222124,"start_time":1687222124,"finished_time":1687222126,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1929664","created_time":1687220528,"start_time":1687220529,"finished_time":1687221082,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1866986","created_time":1687219571,"start_time":1687219571,"finished_time":1687219600,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1935460","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":5468,"memory":0.13724800292402506}
-{"account_id":10730,"name":"query:0123/job_id:1902908","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":1997,"memory":0.05740081053227186}
-{"account_id":10730,"name":"query:0123/job_id:1879666","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":35,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1867388","created_time":1687221348,"start_time":1687221348,"finished_time":1687221351,"cpu":28,"memory":0.000028837472200393677}
-{"account_id":10730,"name":"query:0123/job_id:1928237","created_time":1687219498,"start_time":1687219498,"finished_time":1687219509,"cpu":1724,"memory":0.0018572863191366196}
-{"account_id":10730,"name":"query:0123/job_id:1859711","created_time":1687221383,"start_time":1687221383,"finished_time":1687221388,"cpu":1741,"memory":0.0024359971284866333}
-{"account_id":10730,"name":"query:0123/job_id:1884609","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":154679,"memory":5.28403483517468}
-{"account_id":10730,"name":"query:0123/job_id:1870086","created_time":1687222261,"start_time":1687222261,"finished_time":1687222281,"cpu":137348,"memory":6.620400631800294}
-{"account_id":10730,"name":"query:0123/job_id:1945737","created_time":1687221896,"start_time":1687221896,"finished_time":1687221897,"cpu":31,"memory":0.00004255864769220352}
-{"account_id":10730,"name":"query:0123/job_id:1909344","created_time":1687220526,"start_time":1687220526,"finished_time":1687220654,"cpu":6278421,"memory":82.99605563655496}
-{"account_id":10730,"name":"query:0123/job_id:1901760","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":8868,"memory":0.48437179904431105}
-{"account_id":10730,"name":"query:0123/job_id:1887962","created_time":1687222248,"start_time":1687222248,"finished_time":1687222264,"cpu":25366,"memory":0.0007336661219596863}
-{"account_id":10730,"name":"query:0123/job_id:1866695","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":27,"memory":9.08970832824707e-7}
-{"account_id":10730,"name":"query:0123/job_id:1867486","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1936848","created_time":1687220063,"start_time":1687220063,"finished_time":1687220069,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1936567","created_time":1687220079,"start_time":1687220079,"finished_time":1687220080,"cpu":4,"memory":2.60770320892334e-7}
-{"account_id":10730,"name":"query:0123/job_id:1860651","created_time":1687219491,"start_time":1687219491,"finished_time":1687219493,"cpu":4,"memory":2.5331974029541016e-7}
-{"account_id":10730,"name":"query:0123/job_id:1936743","created_time":1687220059,"start_time":1687220059,"finished_time":1687220070,"cpu":84057,"memory":0.581495494581759}
-{"account_id":10730,"name":"query:0123/job_id:1873799","created_time":1687220059,"start_time":1687220059,"finished_time":1687220070,"cpu":29,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1889854","created_time":1687222516,"start_time":1687222516,"finished_time":1687222530,"cpu":1349213,"memory":25.21270072646439}
-{"account_id":10730,"name":"query:0123/job_id:1909449","created_time":1687222272,"start_time":1687222272,"finished_time":1687222275,"cpu":47,"memory":4.544854164123535e-7}
-{"account_id":10730,"name":"query:0123/job_id:1858455","created_time":1687222036,"start_time":1687222036,"finished_time":1687222040,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1869922","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":34,"memory":0.00014067348092794418}
-{"account_id":10730,"name":"query:0123/job_id:1923240","created_time":1687221366,"start_time":1687221366,"finished_time":1687221389,"cpu":173155,"memory":0.6662634816020727}
-{"account_id":10730,"name":"query:0123/job_id:1878433","created_time":1687220063,"start_time":1687220064,"finished_time":1687220066,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1918956","created_time":1687219798,"start_time":1687219798,"finished_time":1687219802,"cpu":1775,"memory":0.0013281740248203278}
-{"account_id":10730,"name":"query:0123/job_id:1873160","created_time":1687222279,"start_time":1687222279,"finished_time":1687222512,"cpu":1475072,"memory":29.879191937856376}
-{"account_id":10730,"name":"query:0123/job_id:1867885","created_time":1687222095,"start_time":1687222095,"finished_time":1687222099,"cpu":274,"memory":0.00003236904740333557}
-{"account_id":10730,"name":"query:0123/job_id:1945687","created_time":1687222069,"start_time":1687222069,"finished_time":1687222071,"cpu":133,"memory":0.00003302004188299179}
-{"account_id":10730,"name":"query:0123/job_id:1899200","created_time":1687222128,"start_time":1687222128,"finished_time":1687222138,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1903354","created_time":1687222229,"start_time":1687222230,"finished_time":1687222234,"cpu":14475,"memory":0.8644355805590749}
-{"account_id":10730,"name":"query:0123/job_id:1875296","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":1871,"memory":0.02522611990571022}
-{"account_id":10730,"name":"query:0123/job_id:1927102","created_time":1687220065,"start_time":1687220065,"finished_time":1687220070,"cpu":2620,"memory":0.0894061429426074}
-{"account_id":10730,"name":"query:0123/job_id:1913690","created_time":1687220065,"start_time":1687220065,"finished_time":1687220070,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1925529","created_time":1687221300,"start_time":1687221300,"finished_time":1687221317,"cpu":171333,"memory":0.6323725860565901}
-{"account_id":10730,"name":"query:0123/job_id:1945868","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":32,"memory":0.0000024242326617240906}
-{"account_id":10730,"name":"query:0123/job_id:1854845","created_time":1687222260,"start_time":1687222260,"finished_time":1687224138,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1890633","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":26,"memory":3.4086406230926514e-7}
-{"account_id":10730,"name":"query:0123/job_id:1910966","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":60,"memory":0.0005310773849487305}
-{"account_id":10730,"name":"query:0123/job_id:1953345","created_time":1687220065,"start_time":1687220065,"finished_time":1687220139,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1944770","created_time":1687221419,"start_time":1687221419,"finished_time":1687221422,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1860300","created_time":1687220058,"start_time":1687220058,"finished_time":1687220059,"cpu":33,"memory":0.0000020060688257217407}
-{"account_id":10730,"name":"query:0123/job_id:1854308","created_time":1687220045,"start_time":1687220045,"finished_time":1687220049,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1917073","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":33,"memory":0.000001912936568260193}
-{"account_id":10730,"name":"query:0123/job_id:1874552","created_time":1687222495,"start_time":1687222495,"finished_time":1687222496,"cpu":55,"memory":0.00005161110311746597}
-{"account_id":10730,"name":"query:0123/job_id:1874115","created_time":1687222233,"start_time":1687222234,"finished_time":1687222238,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1906357","created_time":1687221871,"start_time":1687221871,"finished_time":1687221912,"cpu":1413226,"memory":0.030194759368896484}
-{"account_id":10730,"name":"query:0123/job_id:1929412","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":30,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1877755","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":8,"memory":5.112960934638977e-7}
-{"account_id":10730,"name":"query:0123/job_id:1937715","created_time":1687222532,"start_time":1687222532,"finished_time":1687222563,"cpu":877663,"memory":37.235547291114926}
-{"account_id":10730,"name":"query:0123/job_id:1896383","created_time":1687220700,"start_time":1687220700,"finished_time":1687220711,"cpu":9166,"memory":0.40832468774169683}
-{"account_id":10730,"name":"query:0123/job_id:1892286","created_time":1687222088,"start_time":1687222088,"finished_time":1687222092,"cpu":147,"memory":0.0038497494533658028}
-{"account_id":10730,"name":"query:0123/job_id:1865696","created_time":1687219626,"start_time":1687219627,"finished_time":1687219628,"cpu":0,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1888402","created_time":1687221400,"start_time":1687221401,"finished_time":1687221420,"cpu":214993,"memory":7.887006695382297}
-{"account_id":10730,"name":"query:0123/job_id:1912452","created_time":1687220047,"start_time":1687220048,"finished_time":1687220051,"cpu":4269,"memory":0.11234669387340546}
-{"account_id":10730,"name":"query:0123/job_id:1938477","created_time":1687222003,"start_time":1687222003,"finished_time":1687222005,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1865402","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1952310","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":5800,"memory":0.0347793772816658}
-{"account_id":10730,"name":"query:0123/job_id:1938893","created_time":1687220915,"start_time":1687220915,"finished_time":1687220922,"cpu":2609,"memory":0.28729093074798584}
-{"account_id":10730,"name":"query:0123/job_id:1877272","created_time":1687221389,"start_time":1687221389,"finished_time":1687221396,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1915604","created_time":1687221490,"start_time":1687221490,"finished_time":1687221521,"cpu":45384,"memory":0.9703322276473045}
-{"account_id":10730,"name":"query:0123/job_id:1878331","created_time":1687219538,"start_time":1687219538,"finished_time":1687219540,"cpu":3,"memory":2.812594175338745e-7}
-{"account_id":10730,"name":"query:0123/job_id:1903504","created_time":1687222030,"start_time":1687222030,"finished_time":1687222034,"cpu":14,"memory":0.000007779337465763092}
-{"account_id":10730,"name":"query:0123/job_id:1935890","created_time":1687222242,"start_time":1687222242,"finished_time":1687222257,"cpu":69911,"memory":4.9587449841201305}
-{"account_id":10730,"name":"query:0123/job_id:1882046","created_time":1687221595,"start_time":1687221596,"finished_time":1687221604,"cpu":1202,"memory":0.12898958288133144}
-{"account_id":10730,"name":"query:0123/job_id:1864005","created_time":1687221919,"start_time":1687221919,"finished_time":1687221921,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1937951","created_time":1687221357,"start_time":1687221358,"finished_time":1687221360,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1949694","created_time":1687222330,"start_time":1687222330,"finished_time":1687222331,"cpu":25,"memory":0.0005985591560602188}
-{"account_id":10730,"name":"query:0123/job_id:1924263","created_time":1687219956,"start_time":1687219957,"finished_time":1687220122,"cpu":4701057,"memory":277.56208450719714}
-{"account_id":10730,"name":"query:0123/job_id:1916975","created_time":1687221964,"start_time":1687221964,"finished_time":1687221964,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1940384","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":52,"memory":0.00014798343181610107}
-{"account_id":10730,"name":"query:0123/job_id:1856979","created_time":1687219645,"start_time":1687219646,"finished_time":1687219652,"cpu":1762,"memory":0.0014302656054496765}
-{"account_id":10730,"name":"query:0123/job_id:1870846","created_time":1687221936,"start_time":1687221936,"finished_time":1687221938,"cpu":0,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1906933","created_time":1687219765,"start_time":1687219765,"finished_time":1687219767,"cpu":1,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1874309","created_time":1687222104,"start_time":1687222104,"finished_time":1687222121,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1933610","created_time":1687219687,"start_time":1687219687,"finished_time":1687219696,"cpu":12523,"memory":0.29332683701068163}
-{"account_id":10730,"name":"query:0123/job_id:1904123","created_time":1687219687,"start_time":1687219687,"finished_time":1687219696,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1857757","created_time":1687222095,"start_time":1687222095,"finished_time":1687222099,"cpu":699,"memory":0.000017278827726840973}
-{"account_id":10730,"name":"query:0123/job_id:1947773","created_time":1687222063,"start_time":1687222063,"finished_time":1687222072,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1885116","created_time":1687222108,"start_time":1687222108,"finished_time":1687222154,"cpu":1724822,"memory":122.43716402724385}
-{"account_id":10730,"name":"query:0123/job_id:1935071","created_time":1687221365,"start_time":1687221365,"finished_time":1687221367,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1878799","created_time":1687222107,"start_time":1687222107,"finished_time":1687222120,"cpu":211059,"memory":11.376393739134073}
-{"account_id":10730,"name":"query:0123/job_id:1941097","created_time":1687219441,"start_time":1687219441,"finished_time":1687219446,"cpu":144,"memory":0.000029970891773700714}
-{"account_id":10730,"name":"query:0123/job_id:1862051","created_time":1687219688,"start_time":1687219688,"finished_time":1687219730,"cpu":528966,"memory":6.334656901657581}
-{"account_id":10730,"name":"query:0123/job_id:1914382","created_time":1687222056,"start_time":1687222056,"finished_time":1687222095,"cpu":995100,"memory":32.03270216938108}
-{"account_id":10730,"name":"query:0123/job_id:1875788","created_time":1687219507,"start_time":1687219507,"finished_time":1687219513,"cpu":8,"memory":3.4086406230926514e-7}
-{"account_id":10730,"name":"query:0123/job_id:1941847","created_time":1687222124,"start_time":1687222125,"finished_time":1687222126,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1863240","created_time":1687220700,"start_time":1687220700,"finished_time":1687220711,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1910737","created_time":1687220065,"start_time":1687220065,"finished_time":1687220083,"cpu":238857,"memory":0.27852213103324175}
-{"account_id":10730,"name":"query:0123/job_id:1915625","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":1384,"memory":0.034782237373292446}
-{"account_id":10730,"name":"query:0123/job_id:1887339","created_time":1687219571,"start_time":1687219571,"finished_time":1687219600,"cpu":275253,"memory":3.5219838758930564}
-{"account_id":10730,"name":"query:0123/job_id:1903586","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":753,"memory":0.005912870168685913}
-{"account_id":10730,"name":"query:0123/job_id:1882752","created_time":1687220072,"start_time":1687220072,"finished_time":1687220073,"cpu":4,"memory":3.818422555923462e-7}
-{"account_id":10730,"name":"query:0123/job_id:1923327","created_time":1687219721,"start_time":1687219721,"finished_time":1687219722,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1865356","created_time":1687219687,"start_time":1687219687,"finished_time":1687219688,"cpu":3,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1883618","created_time":1687219764,"start_time":1687219764,"finished_time":1687219937,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1876943","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":35,"memory":6.975606083869934e-7}
-{"account_id":10730,"name":"query:0123/job_id:1891564","created_time":1687221936,"start_time":1687221936,"finished_time":1687221938,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1884446","created_time":1687219663,"start_time":1687219663,"finished_time":1687219672,"cpu":36963,"memory":0.1375558190047741}
-{"account_id":10730,"name":"query:0123/job_id:1943959","created_time":1687220047,"start_time":1687220047,"finished_time":1687220049,"cpu":26,"memory":8.437782526016235e-7}
-{"account_id":10730,"name":"query:0123/job_id:1887252","created_time":1687221403,"start_time":1687221403,"finished_time":1687221408,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1882584","created_time":1687222196,"start_time":1687222196,"finished_time":1687222203,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1926303","created_time":1687222104,"start_time":1687222104,"finished_time":1687222121,"cpu":88601,"memory":3.038497334346175}
-{"account_id":10730,"name":"query:0123/job_id:1913824","created_time":1687221919,"start_time":1687221919,"finished_time":1687221969,"cpu":85583,"memory":1.6815164554864168}
-{"account_id":10730,"name":"query:0123/job_id:1859247","created_time":1687221389,"start_time":1687221389,"finished_time":1687221396,"cpu":15,"memory":0.000003471970558166504}
-{"account_id":10730,"name":"query:0123/job_id:1889364","created_time":1687219366,"start_time":1687219366,"finished_time":1687219539,"cpu":3227336,"memory":186.95616215001792}
-{"account_id":10730,"name":"query:0123/job_id:1941061","created_time":1687219511,"start_time":1687219511,"finished_time":1687219522,"cpu":40,"memory":0.00010661780834197998}
-{"account_id":10730,"name":"query:0123/job_id:1880772","created_time":1687219511,"start_time":1687219511,"finished_time":1687219522,"cpu":0,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1922530","created_time":1687222063,"start_time":1687222063,"finished_time":1687222072,"cpu":66642,"memory":7.241031132638454}
-{"account_id":10730,"name":"query:0123/job_id:1928114","created_time":1687222272,"start_time":1687222272,"finished_time":1687222275,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1936782","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":27,"memory":5.112960934638977e-7}
-{"account_id":10730,"name":"query:0123/job_id:1937360","created_time":1687220719,"start_time":1687220720,"finished_time":1687220724,"cpu":1508,"memory":0.055711349472403526}
-{"account_id":10730,"name":"query:0123/job_id:1953784","created_time":1687222017,"start_time":1687222017,"finished_time":1687222025,"cpu":152,"memory":0.02313260082155466}
-{"account_id":10730,"name":"query:0123/job_id:1940844","created_time":1687222108,"start_time":1687222108,"finished_time":1687222154,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1925233","created_time":1687219728,"start_time":1687219728,"finished_time":1687219730,"cpu":4,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1938438","created_time":1687219619,"start_time":1687219619,"finished_time":1687219662,"cpu":337463,"memory":7.5993646727874875}
-{"account_id":10730,"name":"query:0123/job_id:1898320","created_time":1687219619,"start_time":1687219619,"finished_time":1687219662,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1869160","created_time":1687222078,"start_time":1687222079,"finished_time":1687222101,"cpu":385234,"memory":18.12602466996759}
-{"account_id":10730,"name":"query:0123/job_id:1858876","created_time":1687219425,"start_time":1687219425,"finished_time":1687219436,"cpu":672,"memory":0.000019224360585212708}
-{"account_id":10730,"name":"query:0123/job_id:1858376","created_time":1687222229,"start_time":1687222230,"finished_time":1687222234,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1937240","created_time":1687221894,"start_time":1687221894,"finished_time":1687221895,"cpu":24,"memory":0.00005719717592000961}
-{"account_id":10730,"name":"query:0123/job_id:1864616","created_time":1687221988,"start_time":1687221988,"finished_time":1687221989,"cpu":2,"memory":4.7124922275543213e-7}
-{"account_id":10730,"name":"query:0123/job_id:1940461","created_time":1687219688,"start_time":1687219688,"finished_time":1687219730,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1880316","created_time":1687220519,"start_time":1687220519,"finished_time":1687220521,"cpu":1796,"memory":0.028349141590297222}
-{"account_id":10730,"name":"query:0123/job_id:1873646","created_time":1687220729,"start_time":1687220729,"finished_time":1687220741,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1856989","created_time":1687222190,"start_time":1687222190,"finished_time":1687222194,"cpu":1042,"memory":0.15664026141166687}
-{"account_id":10730,"name":"query:0123/job_id:1898817","created_time":1687221911,"start_time":1687221911,"finished_time":1687221913,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1872651","created_time":1687219690,"start_time":1687219690,"finished_time":1687219694,"cpu":132,"memory":0.00002968963235616684}
-{"account_id":10730,"name":"query:0123/job_id:1887504","created_time":1687219478,"start_time":1687219478,"finished_time":1687219482,"cpu":40,"memory":0.00011587142944335938}
-{"account_id":10730,"name":"query:0123/job_id:1914521","created_time":1687222050,"start_time":1687222050,"finished_time":1687222051,"cpu":1,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1869944","created_time":1687221919,"start_time":1687221919,"finished_time":1687221921,"cpu":0,"memory":2.2724270820617676e-7}
-{"account_id":10730,"name":"query:0123/job_id:1915351","created_time":1687220621,"start_time":1687220621,"finished_time":1687220623,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1913246","created_time":1687221922,"start_time":1687221922,"finished_time":1687221923,"cpu":20,"memory":0.00005175638943910599}
-{"account_id":10730,"name":"query:0123/job_id:1858277","created_time":1687222471,"start_time":1687222471,"finished_time":1687222476,"cpu":197767,"memory":0.1941282246261835}
-{"account_id":10730,"name":"query:0123/job_id:1941474","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1858285","created_time":1687222070,"start_time":1687222070,"finished_time":1687222072,"cpu":63,"memory":0.0001813843846321106}
-{"account_id":10730,"name":"query:0123/job_id:1929738","created_time":1687221927,"start_time":1687221928,"finished_time":1687221929,"cpu":1,"memory":1.7043203115463257e-7}
-{"account_id":10730,"name":"query:0123/job_id:1922442","created_time":1687222182,"start_time":1687222182,"finished_time":1687222192,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1890458","created_time":1687220046,"start_time":1687220046,"finished_time":1687220049,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1936446","created_time":1687220046,"start_time":1687220046,"finished_time":1687220049,"cpu":425,"memory":0.015547140501439571}
-{"account_id":10730,"name":"query:0123/job_id:1928174","created_time":1687222088,"start_time":1687222088,"finished_time":1687222092,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1947301","created_time":1687222279,"start_time":1687222279,"finished_time":1687222280,"cpu":1,"memory":0.00001825764775276184}
-{"account_id":10730,"name":"query:0123/job_id:1888759","created_time":1687220063,"start_time":1687220063,"finished_time":1687220069,"cpu":1678,"memory":0.050700913183391094}
-{"account_id":10730,"name":"query:0123/job_id:1861676","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1863973","created_time":1687222196,"start_time":1687222196,"finished_time":1687222203,"cpu":76052,"memory":1.4273631423711777}
-{"account_id":10730,"name":"query:0123/job_id:1913657","created_time":1687221403,"start_time":1687221403,"finished_time":1687221408,"cpu":11396,"memory":0.462107015773654}
-{"account_id":10730,"name":"query:0123/job_id:1876712","created_time":1687219446,"start_time":1687219447,"finished_time":1687219449,"cpu":2,"memory":5.941838026046753e-7}
-{"account_id":10730,"name":"query:0123/job_id:1920207","created_time":1687219765,"start_time":1687219765,"finished_time":1687219767,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1917638","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":2477,"memory":0.19905488658696413}
-{"account_id":10730,"name":"query:0123/job_id:1938804","created_time":1687222198,"start_time":1687222199,"finished_time":1687222203,"cpu":8732,"memory":0.12800941988825798}
-{"account_id":10730,"name":"query:0123/job_id:1868195","created_time":1687222224,"start_time":1687222224,"finished_time":1687222228,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1904594","created_time":1687219562,"start_time":1687219562,"finished_time":1687219562,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1942652","created_time":1687219713,"start_time":1687219713,"finished_time":1687219716,"cpu":133,"memory":0.0003508310765028}
-{"account_id":10730,"name":"query:0123/job_id:1923138","created_time":1687220033,"start_time":1687220033,"finished_time":1687220037,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1925388","created_time":1687222209,"start_time":1687222209,"finished_time":1687222222,"cpu":147907,"memory":3.05915738735348}
-{"account_id":10730,"name":"query:0123/job_id:1920452","created_time":1687222209,"start_time":1687222209,"finished_time":1687222222,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1864086","created_time":1687222480,"start_time":1687222480,"finished_time":1687222495,"cpu":863380,"memory":27.77284919284284}
-{"account_id":10730,"name":"query:0123/job_id:1892514","created_time":1687222242,"start_time":1687222242,"finished_time":1687222257,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1948150","created_time":1687221336,"start_time":1687221336,"finished_time":1687221341,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1889033","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879781","created_time":1687221903,"start_time":1687221903,"finished_time":1687221906,"cpu":76,"memory":0.016456210985779762}
-{"account_id":10730,"name":"query:0123/job_id:1913073","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1880113","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":18,"memory":0.0000034086406230926514}
-{"account_id":10730,"name":"query:0123/job_id:1906863","created_time":1687220969,"start_time":1687220969,"finished_time":1687220972,"cpu":161,"memory":0.00003048870712518692}
-{"account_id":10730,"name":"query:0123/job_id:1888950","created_time":1687221067,"start_time":1687221067,"finished_time":1687221067,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1945541","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":12682,"memory":0.5331832701340318}
-{"account_id":10730,"name":"query:0123/job_id:1938116","created_time":1687222096,"start_time":1687222096,"finished_time":1687222101,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1867683","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":1831,"memory":0.034573921002447605}
-{"account_id":10730,"name":"query:0123/job_id:1950331","created_time":1687221468,"start_time":1687221468,"finished_time":1687221469,"cpu":1,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1918267","created_time":1687222247,"start_time":1687222247,"finished_time":1687222263,"cpu":24938,"memory":0.00017203297466039658}
-{"account_id":10730,"name":"query:0123/job_id:1891576","created_time":1687220528,"start_time":1687220529,"finished_time":1687221082,"cpu":11871969,"memory":1635.820930318907}
-{"account_id":10730,"name":"query:0123/job_id:1936057","created_time":1687221460,"start_time":1687221460,"finished_time":1687221466,"cpu":37261,"memory":0.045606739819049835}
-{"account_id":10730,"name":"query:0123/job_id:1888334","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":31,"memory":0.00010038726031780243}
-{"account_id":10730,"name":"query:0123/job_id:1925524","created_time":1687222554,"start_time":1687222554,"finished_time":1687222556,"cpu":4,"memory":3.259629011154175e-7}
-{"account_id":10730,"name":"query:0123/job_id:1938038","created_time":1687221414,"start_time":1687221414,"finished_time":1687221426,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1928078","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":8164,"memory":0.017148369923233986}
-{"account_id":10730,"name":"query:0123/job_id:1929945","created_time":1687219394,"start_time":1687219395,"finished_time":1687220980,"cpu":198996631,"memory":4.554481757804751}
-{"account_id":10730,"name":"query:0123/job_id:1952857","created_time":1687220063,"start_time":1687220064,"finished_time":1687220066,"cpu":305,"memory":0.014173568226397038}
-{"account_id":10730,"name":"query:0123/job_id:1908775","created_time":1687221678,"start_time":1687221678,"finished_time":1687221690,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1950404","created_time":1687222198,"start_time":1687222199,"finished_time":1687222203,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1879996","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000034086406230926514}
-{"account_id":10730,"name":"query:0123/job_id:1949944","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":0,"memory":1.7043203115463257e-7}
-{"account_id":10730,"name":"query:0123/job_id:1874780","created_time":1687221652,"start_time":1687221652,"finished_time":1687221663,"cpu":142393,"memory":0.3617932302877307}
-{"account_id":10730,"name":"query:0123/job_id:1946424","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1923353","created_time":1687221396,"start_time":1687221396,"finished_time":1687221398,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1942691","created_time":1687221495,"start_time":1687221496,"finished_time":1687221556,"cpu":410525,"memory":0.5270743481814861}
-{"account_id":10730,"name":"query:0123/job_id:1869694","created_time":1687221137,"start_time":1687221137,"finished_time":1687221139,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1953982","created_time":1687221450,"start_time":1687221450,"finished_time":1687221454,"cpu":1692,"memory":0.002086389809846878}
-{"account_id":10730,"name":"query:0123/job_id:1921234","created_time":1687221054,"start_time":1687221054,"finished_time":1687221054,"cpu":0,"memory":1.4808028936386108e-7}
-{"account_id":10730,"name":"query:0123/job_id:1943725","created_time":1687221402,"start_time":1687221402,"finished_time":1687221414,"cpu":123659,"memory":7.229120437987149}
-{"account_id":10730,"name":"query:0123/job_id:1947001","created_time":1687221487,"start_time":1687221488,"finished_time":1687221488,"cpu":0,"memory":1.778826117515564e-7}
-{"account_id":10730,"name":"query:0123/job_id:1859772","created_time":1687221357,"start_time":1687221358,"finished_time":1687221360,"cpu":407,"memory":0.0025974735617637634}
-{"account_id":10730,"name":"query:0123/job_id:1855966","created_time":1687221146,"start_time":1687221146,"finished_time":1687221147,"cpu":2,"memory":2.8312206268310547e-7}
-{"account_id":10730,"name":"query:0123/job_id:1902996","created_time":1687220959,"start_time":1687220959,"finished_time":1687220962,"cpu":155,"memory":0.00001742597669363022}
-{"account_id":10730,"name":"query:0123/job_id:1901548","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1909353","created_time":1687221476,"start_time":1687221476,"finished_time":1687221485,"cpu":12879,"memory":0.18855485878884792}
-{"account_id":10730,"name":"query:0123/job_id:1946665","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":26,"memory":6.817281246185303e-7}
-{"account_id":10730,"name":"query:0123/job_id:1894696","created_time":1687222247,"start_time":1687222247,"finished_time":1687222250,"cpu":12623,"memory":0.0005376730114221573}
-{"account_id":10730,"name":"query:0123/job_id:1857301","created_time":1687221157,"start_time":1687221157,"finished_time":1687221161,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1866817","created_time":1687220064,"start_time":1687220064,"finished_time":1687220096,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1918831","created_time":1687222210,"start_time":1687222210,"finished_time":1687222218,"cpu":22694,"memory":0.3896253043785691}
-{"account_id":10730,"name":"query:0123/job_id:1917594","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":62,"memory":0.0006200522184371948}
-{"account_id":10730,"name":"query:0123/job_id:1875286","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1878054","created_time":1687220516,"start_time":1687220516,"finished_time":1687220517,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1878933","created_time":1687221659,"start_time":1687221659,"finished_time":1687221673,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1872495","created_time":1687221659,"start_time":1687221659,"finished_time":1687221673,"cpu":59367,"memory":2.1684274496510625}
-{"account_id":10730,"name":"query:0123/job_id:1919112","created_time":1687222378,"start_time":1687222378,"finished_time":1687222379,"cpu":178,"memory":0.0037594372406601906}
-{"account_id":10730,"name":"query:0123/job_id:1891430","created_time":1687221445,"start_time":1687221445,"finished_time":1687221450,"cpu":8412,"memory":0.3779042772948742}
-{"account_id":10730,"name":"query:0123/job_id:1868488","created_time":1687221743,"start_time":1687221743,"finished_time":1687221745,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1931802","created_time":1687221743,"start_time":1687221743,"finished_time":1687221745,"cpu":19,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1944697","created_time":1687221817,"start_time":1687221817,"finished_time":1687221818,"cpu":0,"memory":1.685693860054016e-7}
-{"account_id":10730,"name":"query:0123/job_id:1933522","created_time":1687221167,"start_time":1687221167,"finished_time":1687221170,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1884559","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":1500,"memory":0.03479896765202284}
-{"account_id":10730,"name":"query:0123/job_id:1911045","created_time":1687221819,"start_time":1687221819,"finished_time":1687221827,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1919996","created_time":1687221988,"start_time":1687221988,"finished_time":1687221990,"cpu":2,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1889649","created_time":1687221564,"start_time":1687221564,"finished_time":1687221565,"cpu":29,"memory":0.000036937184631824493}
-{"account_id":10730,"name":"query:0123/job_id:1923256","created_time":1687221547,"start_time":1687221547,"finished_time":1687221548,"cpu":9,"memory":0.000005221925675868988}
-{"account_id":10730,"name":"query:0123/job_id:1899625","created_time":1687220932,"start_time":1687220932,"finished_time":1687220940,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1928598","created_time":1687221460,"start_time":1687221460,"finished_time":1687221462,"cpu":5,"memory":7.031485438346863e-7}
-{"account_id":10730,"name":"query:0123/job_id:1938084","created_time":1687221848,"start_time":1687221848,"finished_time":1687221853,"cpu":1837,"memory":0.0042940182611346245}
-{"account_id":10730,"name":"query:0123/job_id:1876258","created_time":1687221163,"start_time":1687221163,"finished_time":1687221179,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1910167","created_time":1687221474,"start_time":1687221474,"finished_time":1687221527,"cpu":1444850,"memory":0.017147465609014034}
-{"account_id":10730,"name":"query:0123/job_id:1954326","created_time":1687221731,"start_time":1687221731,"finished_time":1687221735,"cpu":2541,"memory":0.07881707511842251}
-{"account_id":10730,"name":"query:0123/job_id:1925064","created_time":1687221053,"start_time":1687221053,"finished_time":1687221054,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1903701","created_time":1687221338,"start_time":1687221338,"finished_time":1687221352,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1926984","created_time":1687222592,"start_time":1687222592,"finished_time":1687222594,"cpu":1,"memory":1.4062970876693726e-7}
-{"account_id":10730,"name":"query:0123/job_id:1887053","created_time":1687221620,"start_time":1687221620,"finished_time":1687221621,"cpu":0,"memory":2.598389983177185e-7}
-{"account_id":10730,"name":"query:0123/job_id:1866475","created_time":1687221065,"start_time":1687221065,"finished_time":1687221065,"cpu":0,"memory":2.896413207054138e-7}
-{"account_id":10730,"name":"query:0123/job_id:1902305","created_time":1687219840,"start_time":1687219840,"finished_time":1687220117,"cpu":6755107,"memory":668.3046566024423}
-{"account_id":10730,"name":"query:0123/job_id:1905411","created_time":1687222329,"start_time":1687222329,"finished_time":1687222339,"cpu":24433,"memory":0.002141670323908329}
-{"account_id":10730,"name":"query:0123/job_id:1869286","created_time":1687220065,"start_time":1687220065,"finished_time":1687220083,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1867250","created_time":1687218886,"start_time":1687218886,"finished_time":1687221999,"cpu":12709733,"memory":2779.913918171078}
-{"account_id":10730,"name":"query:0123/job_id:1871280","created_time":1687221432,"start_time":1687221432,"finished_time":1687221436,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1887946","created_time":1687221394,"start_time":1687221394,"finished_time":1687221396,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1951346","created_time":1687220690,"start_time":1687220690,"finished_time":1687220694,"cpu":0,"memory":0.0}
-{"account_id":10730,"name":"query:0123/job_id:1900912","created_time":1687222022,"start_time":1687222022,"finished_time":1687222031,"cpu":1715,"memory":0.06944573298096657}
+[
+  {"account_id":10730,"name":"query:0123/job_id:1912004","created_time":1687219221,"start_time":1687219221,"finished_time":1687219230,"cpu":926,"memory":0.033250387758016586},
+  {"account_id":10730,"name":"query:0123/job_id:1925601","created_time":1687219605,"start_time":1687219605,"finished_time":1687219609,"cpu":94,"memory":0.002556886523962021},
+  {"account_id":10730,"name":"query:0123/job_id:1931905","created_time":1687221543,"start_time":1687221543,"finished_time":1687221546,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1880528","created_time":1687221153,"start_time":1687221153,"finished_time":1687221154,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1889142","created_time":1687221911,"start_time":1687221911,"finished_time":1687221913,"cpu":0,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1948835","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1908991","created_time":1687221662,"start_time":1687221662,"finished_time":1687221663,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1938420","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":26,"memory":5.681067705154419e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1937417","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1907392","created_time":1687222233,"start_time":1687222234,"finished_time":1687222238,"cpu":3200,"memory":0.21290632057935},
+  {"account_id":10730,"name":"query:0123/job_id:1888958","created_time":1687221673,"start_time":1687221673,"finished_time":1687221686,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1891839","created_time":1687221562,"start_time":1687221562,"finished_time":1687221565,"cpu":98,"memory":0.009178344160318375},
+  {"account_id":10730,"name":"query:0123/job_id:1947110","created_time":1687222330,"start_time":1687222330,"finished_time":1687222332,"cpu":28,"memory":0.0002629132941365242},
+  {"account_id":10730,"name":"query:0123/job_id:1870285","created_time":1687222063,"start_time":1687222063,"finished_time":1687222066,"cpu":140,"memory":0.00003091059625148773},
+  {"account_id":10730,"name":"query:0123/job_id:1866013","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":1398,"memory":0.03518072981387377},
+  {"account_id":10730,"name":"query:0123/job_id:1888131","created_time":1687221155,"start_time":1687221156,"finished_time":1687221160,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1926789","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":974,"memory":0.03765729535371065},
+  {"account_id":10730,"name":"query:0123/job_id:1921568","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":60,"memory":0.0005164733156561852},
+  {"account_id":10730,"name":"query:0123/job_id:1901172","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":27,"memory":3.4086406230926514e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1914114","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":34,"memory":0.0000012200325727462769},
+  {"account_id":10730,"name":"query:0123/job_id:1898269","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000011362135410308838},
+  {"account_id":10730,"name":"query:0123/job_id:1887999","created_time":1687221355,"start_time":1687221355,"finished_time":1687221360,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1892536","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":896,"memory":0.0025287531316280365},
+  {"account_id":10730,"name":"query:0123/job_id:1948422","created_time":1687221342,"start_time":1687221342,"finished_time":1687221345,"cpu":15,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1901357","created_time":1687221342,"start_time":1687221342,"finished_time":1687221345,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1903606","created_time":1687221401,"start_time":1687221401,"finished_time":1687221411,"cpu":74629,"memory":3.5813009943813086},
+  {"account_id":10730,"name":"query:0123/job_id:1896504","created_time":1687222224,"start_time":1687222224,"finished_time":1687222228,"cpu":1655,"memory":0.0606548385694623},
+  {"account_id":10730,"name":"query:0123/job_id:1896401","created_time":1687220598,"start_time":1687220598,"finished_time":1687220605,"cpu":24817,"memory":0.000926673412322998},
+  {"account_id":10730,"name":"query:0123/job_id:1926387","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1939729","created_time":1687222003,"start_time":1687222003,"finished_time":1687222005,"cpu":93,"memory":0.00010114442557096481},
+  {"account_id":10730,"name":"query:0123/job_id:1932968","created_time":1687221366,"start_time":1687221366,"finished_time":1687221374,"cpu":2,"memory":0.000002236105501651764},
+  {"account_id":10730,"name":"query:0123/job_id:1951194","created_time":1687222128,"start_time":1687222128,"finished_time":1687222138,"cpu":55493,"memory":2.2616777988150716},
+  {"account_id":10730,"name":"query:0123/job_id:1942980","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":63,"memory":0.0003394652158021927},
+  {"account_id":10730,"name":"query:0123/job_id:1881222","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":24,"memory":8.521601557731628e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1912566","created_time":1687219506,"start_time":1687219506,"finished_time":1687219509,"cpu":12,"memory":0.000009562820196151733},
+  {"account_id":10730,"name":"query:0123/job_id:1887709","created_time":1687220719,"start_time":1687220720,"finished_time":1687220724,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1920382","created_time":1687219554,"start_time":1687219554,"finished_time":1687219556,"cpu":3,"memory":2.5331974029541016e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1902106","created_time":1687221941,"start_time":1687221941,"finished_time":1687221942,"cpu":1,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1901653","created_time":1687219442,"start_time":1687219442,"finished_time":1687219447,"cpu":144,"memory":0.00036424770951271057},
+  {"account_id":10730,"name":"query:0123/job_id:1877408","created_time":1687219507,"start_time":1687219507,"finished_time":1687219513,"cpu":1,"memory":0.0000011064112186431885},
+  {"account_id":10730,"name":"query:0123/job_id:1942629","created_time":1687219428,"start_time":1687219428,"finished_time":1687219436,"cpu":140,"memory":0.0002106623724102974},
+  {"account_id":10730,"name":"query:0123/job_id:1935066","created_time":1687221413,"start_time":1687221413,"finished_time":1687221416,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1922976","created_time":1687220143,"start_time":1687220143,"finished_time":1687220508,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1854783","created_time":1687220065,"start_time":1687220065,"finished_time":1687220139,"cpu":1252851,"memory":17.947971625253558},
+  {"account_id":10730,"name":"query:0123/job_id:1901449","created_time":1687222287,"start_time":1687222287,"finished_time":1687222294,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1868286","created_time":1687222287,"start_time":1687222287,"finished_time":1687222294,"cpu":40214,"memory":2.2588757760822773},
+  {"account_id":10730,"name":"query:0123/job_id:1907493","created_time":1687222477,"start_time":1687222477,"finished_time":1687222479,"cpu":150771,"memory":0.002548140473663807},
+  {"account_id":10730,"name":"query:0123/job_id:1902108","created_time":1687221586,"start_time":1687221586,"finished_time":1687221686,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1869923","created_time":1687221543,"start_time":1687221543,"finished_time":1687221546,"cpu":426,"memory":0.018877992406487465},
+  {"account_id":10730,"name":"query:0123/job_id:1937874","created_time":1687222512,"start_time":1687222512,"finished_time":1687222514,"cpu":119406,"memory":0.000977061688899994},
+  {"account_id":10730,"name":"query:0123/job_id:1939232","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":56,"memory":0.0006288588047027588},
+  {"account_id":10730,"name":"query:0123/job_id:1857943","created_time":1687221469,"start_time":1687221469,"finished_time":1687221470,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1947090","created_time":1687221009,"start_time":1687221009,"finished_time":1687221016,"cpu":877,"memory":0.029430674389004707},
+  {"account_id":10730,"name":"query:0123/job_id:1878674","created_time":1687221414,"start_time":1687221414,"finished_time":1687221426,"cpu":300010,"memory":1.5748306103050709},
+  {"account_id":10730,"name":"query:0123/job_id:1893029","created_time":1687221652,"start_time":1687221652,"finished_time":1687221663,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1903517","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":284,"memory":0.00008616875857114792},
+  {"account_id":10730,"name":"query:0123/job_id:1945417","created_time":1687221638,"start_time":1687221638,"finished_time":1687221639,"cpu":0,"memory":2.598389983177185e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1903809","created_time":1687220961,"start_time":1687220961,"finished_time":1687220964,"cpu":128,"memory":0.00003502052277326584},
+  {"account_id":10730,"name":"query:0123/job_id:1870659","created_time":1687221396,"start_time":1687221396,"finished_time":1687221398,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1931916","created_time":1687221432,"start_time":1687221432,"finished_time":1687221436,"cpu":8412,"memory":0.31992046628147364},
+  {"account_id":10730,"name":"query:0123/job_id:1893291","created_time":1687221137,"start_time":1687221137,"finished_time":1687221139,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1881715","created_time":1687222064,"start_time":1687222064,"finished_time":1687222066,"cpu":31,"memory":0.000012818723917007446},
+  {"account_id":10730,"name":"query:0123/job_id:1916625","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1906892","created_time":1687221458,"start_time":1687221458,"finished_time":1687221460,"cpu":43,"memory":0.00002164021134376526},
+  {"account_id":10730,"name":"query:0123/job_id:1856958","created_time":1687221394,"start_time":1687221394,"finished_time":1687221396,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1897372","created_time":1687219490,"start_time":1687219491,"finished_time":1687219493,"cpu":9,"memory":0.0000046407803893089294},
+  {"account_id":10730,"name":"query:0123/job_id:1874402","created_time":1687220064,"start_time":1687220064,"finished_time":1687220096,"cpu":96621,"memory":9.694063430652022},
+  {"account_id":10730,"name":"query:0123/job_id:1954135","created_time":1687219480,"start_time":1687219480,"finished_time":1687219484,"cpu":23,"memory":7.348135113716125e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1913260","created_time":1687221920,"start_time":1687221920,"finished_time":1687222037,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1922185","created_time":1687221903,"start_time":1687221903,"finished_time":1687221906,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1886433","created_time":1687222002,"start_time":1687222002,"finished_time":1687222006,"cpu":1745,"memory":0.0030351150780916214},
+  {"account_id":10730,"name":"query:0123/job_id:1913742","created_time":1687219592,"start_time":1687219592,"finished_time":1687219594,"cpu":6,"memory":4.470348358154297e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1885859","created_time":1687221993,"start_time":1687221994,"finished_time":1687221997,"cpu":190,"memory":0.010221323929727077},
+  {"account_id":10730,"name":"query:0123/job_id:1928138","created_time":1687222036,"start_time":1687222036,"finished_time":1687222040,"cpu":63,"memory":0.000019278377294540405},
+  {"account_id":10730,"name":"query:0123/job_id:1922489","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1858862","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":751461,"memory":7.0592819061130285},
+  {"account_id":10730,"name":"query:0123/job_id:1913007","created_time":1687219479,"start_time":1687219479,"finished_time":1687219483,"cpu":1,"memory":0.000008128583431243896},
+  {"account_id":10730,"name":"query:0123/job_id:1862761","created_time":1687219580,"start_time":1687219580,"finished_time":1687219580,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1913479","created_time":1687222044,"start_time":1687222044,"finished_time":1687222053,"cpu":69413,"memory":0.0034308386966586113},
+  {"account_id":10730,"name":"query:0123/job_id:1931906","created_time":1687221948,"start_time":1687221948,"finished_time":1687221949,"cpu":0,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1928862","created_time":1687222078,"start_time":1687222079,"finished_time":1687222101,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1863952","created_time":1687222124,"start_time":1687222124,"finished_time":1687222124,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1870288","created_time":1687219593,"start_time":1687219593,"finished_time":1687219593,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1854445","created_time":1687219766,"start_time":1687219766,"finished_time":1687219768,"cpu":2,"memory":2.2351741790771484e-8},
+  {"account_id":10730,"name":"query:0123/job_id:1919714","created_time":1687221920,"start_time":1687221920,"finished_time":1687222037,"cpu":3295085,"memory":122.1370611274615},
+  {"account_id":10730,"name":"query:0123/job_id:1859251","created_time":1687219719,"start_time":1687219719,"finished_time":1687219797,"cpu":407112,"memory":0.8181027173995972},
+  {"account_id":10730,"name":"query:0123/job_id:1932390","created_time":1687222124,"start_time":1687222124,"finished_time":1687222126,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1864350","created_time":1687219425,"start_time":1687219425,"finished_time":1687219434,"cpu":139,"memory":0.00006481260061264038},
+  {"account_id":10730,"name":"query:0123/job_id:1912121","created_time":1687221338,"start_time":1687221338,"finished_time":1687221352,"cpu":167742,"memory":1.258029531687498},
+  {"account_id":10730,"name":"query:0123/job_id:1951779","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1946539","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":28,"memory":0.000001193024218082428},
+  {"account_id":10730,"name":"query:0123/job_id:1862916","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":31,"memory":0.00001786835491657257},
+  {"account_id":10730,"name":"query:0123/job_id:1931456","created_time":1687219283,"start_time":1687219283,"finished_time":1687219284,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1895437","created_time":1687220206,"start_time":1687220206,"finished_time":1687220210,"cpu":1948,"memory":0.0730581572279334},
+  {"account_id":10730,"name":"query:0123/job_id:1864718","created_time":1687219245,"start_time":1687219245,"finished_time":1687219251,"cpu":124,"memory":0.00005942396819591522},
+  {"account_id":10730,"name":"query:0123/job_id:1870346","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1857902","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":1494,"memory":0.035645054653286934},
+  {"account_id":10730,"name":"query:0123/job_id:1948603","created_time":1687219279,"start_time":1687219279,"finished_time":1687219280,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1930828","created_time":1687220315,"start_time":1687220315,"finished_time":1687220316,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1871634","created_time":1687220143,"start_time":1687220143,"finished_time":1687220508,"cpu":6672697,"memory":642.4476086022332},
+  {"account_id":10730,"name":"query:0123/job_id:1953149","created_time":1687221595,"start_time":1687221595,"finished_time":1687221781,"cpu":6772887,"memory":520.4691209448501},
+  {"account_id":10730,"name":"query:0123/job_id:1914861","created_time":1687219366,"start_time":1687219366,"finished_time":1687219539,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1909009","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1860471","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":35,"memory":6.966292858123779e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1859264","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1952116","created_time":1687221476,"start_time":1687221476,"finished_time":1687221485,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1876283","created_time":1687221566,"start_time":1687221566,"finished_time":1687221594,"cpu":84464,"memory":0.4318245854228735},
+  {"account_id":10730,"name":"query:0123/job_id:1857237","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":63,"memory":0.00033929944038391113},
+  {"account_id":10730,"name":"query:0123/job_id:1910057","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1885038","created_time":1687221700,"start_time":1687221700,"finished_time":1687221717,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1933425","created_time":1687221180,"start_time":1687221180,"finished_time":1687221193,"cpu":141502,"memory":0.3628418678417802},
+  {"account_id":10730,"name":"query:0123/job_id:1854545","created_time":1687219223,"start_time":1687219224,"finished_time":1687219229,"cpu":499,"memory":0.018095098435878754},
+  {"account_id":10730,"name":"query:0123/job_id:1950861","created_time":1687220165,"start_time":1687220165,"finished_time":1687220172,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1856495","created_time":1687221713,"start_time":1687221713,"finished_time":1687221713,"cpu":23,"memory":0.000008493661880493164},
+  {"account_id":10730,"name":"query:0123/job_id:1908744","created_time":1687221207,"start_time":1687221207,"finished_time":1687221221,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1930949","created_time":1687219270,"start_time":1687219270,"finished_time":1687219271,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1896857","created_time":1687221726,"start_time":1687221726,"finished_time":1687221746,"cpu":345782,"memory":15.866151478141546},
+  {"account_id":10730,"name":"query:0123/job_id:1857024","created_time":1687219239,"start_time":1687219239,"finished_time":1687219343,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1934669","created_time":1687221259,"start_time":1687221259,"finished_time":1687221272,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1923121","created_time":1687221166,"start_time":1687221166,"finished_time":1687221169,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1900792","created_time":1687220337,"start_time":1687220337,"finished_time":1687220511,"cpu":1295136,"memory":7.5980514250695705},
+  {"account_id":10730,"name":"query:0123/job_id:1942479","created_time":1687221166,"start_time":1687221166,"finished_time":1687221169,"cpu":1641,"memory":0.012543651275336742},
+  {"account_id":10730,"name":"query:0123/job_id:1892038","created_time":1687220337,"start_time":1687220337,"finished_time":1687220511,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1942067","created_time":1687221794,"start_time":1687221794,"finished_time":1687221797,"cpu":17,"memory":0.000005797483026981354},
+  {"account_id":10730,"name":"query:0123/job_id:1857482","created_time":1687221180,"start_time":1687221181,"finished_time":1687221197,"cpu":142087,"memory":0.38752821646630764},
+  {"account_id":10730,"name":"query:0123/job_id:1918293","created_time":1687220972,"start_time":1687220972,"finished_time":1687220974,"cpu":153,"memory":0.00003400444984436035},
+  {"account_id":10730,"name":"query:0123/job_id:1952573","created_time":1687222564,"start_time":1687222564,"finished_time":1687222564,"cpu":58,"memory":0.00002615712583065033},
+  {"account_id":10730,"name":"query:0123/job_id:1946168","created_time":1687221198,"start_time":1687221198,"finished_time":1687221216,"cpu":303601,"memory":1.5264784283936024},
+  {"account_id":10730,"name":"query:0123/job_id:1875129","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":22,"memory":0.0000011362135410308838},
+  {"account_id":10730,"name":"query:0123/job_id:1921946","created_time":1687220058,"start_time":1687220058,"finished_time":1687220060,"cpu":31,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1891556","created_time":1687222673,"start_time":1687222673,"finished_time":1687222674,"cpu":131,"memory":0.005979131907224655},
+  {"account_id":10730,"name":"query:0123/job_id:1910429","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1892404","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1943290","created_time":1687221678,"start_time":1687221678,"finished_time":1687221690,"cpu":338741,"memory":15.848402245901525},
+  {"account_id":10730,"name":"query:0123/job_id:1893116","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":713,"memory":0.00006329640746116638},
+  {"account_id":10730,"name":"query:0123/job_id:1941804","created_time":1687219803,"start_time":1687219803,"finished_time":1687219809,"cpu":479,"memory":0.04549068585038185},
+  {"account_id":10730,"name":"query:0123/job_id:1916067","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":2672,"memory":0.20393055025488138},
+  {"account_id":10730,"name":"query:0123/job_id:1880706","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":3084,"memory":0.13397594913840294},
+  {"account_id":10730,"name":"query:0123/job_id:1923026","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":188,"memory":0.003415885381400585},
+  {"account_id":10730,"name":"query:0123/job_id:1883921","created_time":1687221064,"start_time":1687221064,"finished_time":1687221066,"cpu":1794,"memory":0.02219575271010399},
+  {"account_id":10730,"name":"query:0123/job_id:1940411","created_time":1687219281,"start_time":1687219281,"finished_time":1687219282,"cpu":0,"memory":2.9616057872772217e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1909408","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":12147,"memory":0.02192867361009121},
+  {"account_id":10730,"name":"query:0123/job_id:1863477","created_time":1687221551,"start_time":1687221551,"finished_time":1687221554,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1877423","created_time":1687221812,"start_time":1687221812,"finished_time":1687221814,"cpu":0,"memory":1.8067657947540283e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1870782","created_time":1687221011,"start_time":1687221011,"finished_time":1687221016,"cpu":465,"memory":0.008985631167888641},
+  {"account_id":10730,"name":"query:0123/job_id:1904356","created_time":1687220327,"start_time":1687220327,"finished_time":1687220328,"cpu":3,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1936714","created_time":1687221791,"start_time":1687221791,"finished_time":1687221796,"cpu":68,"memory":0.00031025707721710205},
+  {"account_id":10730,"name":"query:0123/job_id:1860554","created_time":1687220286,"start_time":1687220286,"finished_time":1687220287,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1909232","created_time":1687220276,"start_time":1687220277,"finished_time":1687220282,"cpu":1749,"memory":0.09938544686883688},
+  {"account_id":10730,"name":"query:0123/job_id:1899682","created_time":1687221307,"start_time":1687221307,"finished_time":1687221312,"cpu":371,"memory":0.020730093121528625},
+  {"account_id":10730,"name":"query:0123/job_id:1902228","created_time":1687221700,"start_time":1687221700,"finished_time":1687221717,"cpu":196451,"memory":14.283711779862642},
+  {"account_id":10730,"name":"query:0123/job_id:1906768","created_time":1687222182,"start_time":1687222182,"finished_time":1687222192,"cpu":78262,"memory":3.15274715423584},
+  {"account_id":10730,"name":"query:0123/job_id:1952622","created_time":1687221243,"start_time":1687221243,"finished_time":1687221246,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1944321","created_time":1687219932,"start_time":1687219932,"finished_time":1687219932,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1947475","created_time":1687221784,"start_time":1687221784,"finished_time":1687221788,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1890579","created_time":1687222769,"start_time":1687222769,"finished_time":1687222770,"cpu":1,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1906299","created_time":1687221149,"start_time":1687221149,"finished_time":1687221150,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1893809","created_time":1687221576,"start_time":1687221576,"finished_time":1687221580,"cpu":468,"memory":0.018266317434608936},
+  {"account_id":10730,"name":"query:0123/job_id:1887634","created_time":1687221211,"start_time":1687221211,"finished_time":1687221219,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1904857","created_time":1687222260,"start_time":1687222260,"finished_time":1687224138,"cpu":15020694,"memory":419.7829972356558},
+  {"account_id":10730,"name":"query:0123/job_id:1948795","created_time":1687221227,"start_time":1687221227,"finished_time":1687221900,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1863378","created_time":1687221227,"start_time":1687221227,"finished_time":1687221900,"cpu":56539252,"memory":0.6547873811796308},
+  {"account_id":10730,"name":"query:0123/job_id:1894057","created_time":1687219270,"start_time":1687219270,"finished_time":1687219273,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1910061","created_time":1687220181,"start_time":1687220181,"finished_time":1687220189,"cpu":13937,"memory":0.8185670180246234},
+  {"account_id":10730,"name":"query:0123/job_id:1893140","created_time":1687220165,"start_time":1687220165,"finished_time":1687220172,"cpu":8561,"memory":0.4186299592256546},
+  {"account_id":10730,"name":"query:0123/job_id:1953233","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1911856","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":26,"memory":5.112960934638977e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1928560","created_time":1687221419,"start_time":1687221419,"finished_time":1687221422,"cpu":194,"memory":0.01991942524909973},
+  {"account_id":10730,"name":"query:0123/job_id:1917536","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":58,"memory":0.0006933510303497314},
+  {"account_id":10730,"name":"query:0123/job_id:1859468","created_time":1687221673,"start_time":1687221673,"finished_time":1687221686,"cpu":168257,"memory":0.7430028775706887},
+  {"account_id":10730,"name":"query:0123/job_id:1896004","created_time":1687221298,"start_time":1687221298,"finished_time":1687221301,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1951253","created_time":1687221272,"start_time":1687221272,"finished_time":1687221286,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879518","created_time":1687221564,"start_time":1687221564,"finished_time":1687221569,"cpu":2601,"memory":0.08853498939424753},
+  {"account_id":10730,"name":"query:0123/job_id:1950539","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":8,"memory":0.000001325272023677826},
+  {"account_id":10730,"name":"query:0123/job_id:1864507","created_time":1687221843,"start_time":1687221843,"finished_time":1687221844,"cpu":0,"memory":1.8067657947540283e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1858299","created_time":1687221701,"start_time":1687221701,"finished_time":1687221716,"cpu":53425,"memory":4.135097972117364},
+  {"account_id":10730,"name":"query:0123/job_id:1902214","created_time":1687221198,"start_time":1687221198,"finished_time":1687221215,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1948154","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":27,"memory":0.0000010225921869277954},
+  {"account_id":10730,"name":"query:0123/job_id:1921846","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":59,"memory":0.0005015730857849121},
+  {"account_id":10730,"name":"query:0123/job_id:1902695","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":31,"memory":0.0000013867393136024475},
+  {"account_id":10730,"name":"query:0123/job_id:1888486","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":18,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1950008","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":28,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1929116","created_time":1687221198,"start_time":1687221198,"finished_time":1687221216,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879948","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000013634562492370605},
+  {"account_id":10730,"name":"query:0123/job_id:1895052","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":112,"memory":0.0036832140758633614},
+  {"account_id":10730,"name":"query:0123/job_id:1873757","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":48,"memory":0.000010829418897628784},
+  {"account_id":10730,"name":"query:0123/job_id:1945201","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1940546","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":1315,"memory":0.07021963689476252},
+  {"account_id":10730,"name":"query:0123/job_id:1889682","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1942594","created_time":1687220147,"start_time":1687220147,"finished_time":1687220151,"cpu":1024,"memory":0.1362330112606287},
+  {"account_id":10730,"name":"query:0123/job_id:1867825","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":2098,"memory":0.021414509043097496},
+  {"account_id":10730,"name":"query:0123/job_id:1904626","created_time":1687221268,"start_time":1687221268,"finished_time":1687221274,"cpu":1898,"memory":0.03817306272685528},
+  {"account_id":10730,"name":"query:0123/job_id:1912913","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":5957,"memory":0.04042312130331993},
+  {"account_id":10730,"name":"query:0123/job_id:1855990","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":1598,"memory":0.03528424259275198},
+  {"account_id":10730,"name":"query:0123/job_id:1948134","created_time":1687221752,"start_time":1687221752,"finished_time":1687221762,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1946338","created_time":1687221752,"start_time":1687221752,"finished_time":1687221762,"cpu":40511,"memory":0.4329881453886628},
+  {"account_id":10730,"name":"query:0123/job_id:1906339","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":5535,"memory":0.01947631500661373},
+  {"account_id":10730,"name":"query:0123/job_id:1910718","created_time":1687219602,"start_time":1687219602,"finished_time":1687219603,"cpu":6,"memory":1.51805579662323e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1902998","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1935454","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1890767","created_time":1687220045,"start_time":1687220045,"finished_time":1687220049,"cpu":1787,"memory":0.03971358947455883},
+  {"account_id":10730,"name":"query:0123/job_id:1876947","created_time":1687219282,"start_time":1687219282,"finished_time":1687219282,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1951482","created_time":1687219390,"start_time":1687219390,"finished_time":1687219390,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1864434","created_time":1687221784,"start_time":1687221784,"finished_time":1687221788,"cpu":206,"memory":0.04022339545190334},
+  {"account_id":10730,"name":"query:0123/job_id:1938188","created_time":1687221286,"start_time":1687221286,"finished_time":1687221289,"cpu":33,"memory":0.0000010365620255470276},
+  {"account_id":10730,"name":"query:0123/job_id:1943010","created_time":1687221756,"start_time":1687221756,"finished_time":1687221776,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1895516","created_time":1687221207,"start_time":1687221207,"finished_time":1687221221,"cpu":166350,"memory":0.635268528945744},
+  {"account_id":10730,"name":"query:0123/job_id:1916059","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1908730","created_time":1687221229,"start_time":1687221229,"finished_time":1687221236,"cpu":1527,"memory":0.03525341860949993},
+  {"account_id":10730,"name":"query:0123/job_id:1941362","created_time":1687221211,"start_time":1687221211,"finished_time":1687221219,"cpu":21002,"memory":1.09300653077662},
+  {"account_id":10730,"name":"query:0123/job_id:1925571","created_time":1687221701,"start_time":1687221701,"finished_time":1687221716,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1929307","created_time":1687221258,"start_time":1687221258,"finished_time":1687221263,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1895303","created_time":1687221756,"start_time":1687221756,"finished_time":1687221776,"cpu":195149,"memory":14.429218634031713},
+  {"account_id":10730,"name":"query:0123/job_id:1879960","created_time":1687221773,"start_time":1687221773,"finished_time":1687221774,"cpu":2,"memory":2.812594175338745e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1879934","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":1847,"memory":0.03789173625409603},
+  {"account_id":10730,"name":"query:0123/job_id:1894612","created_time":1687221366,"start_time":1687221366,"finished_time":1687221366,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1859386","created_time":1687219840,"start_time":1687219840,"finished_time":1687220117,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1923169","created_time":1687221198,"start_time":1687221198,"finished_time":1687221215,"cpu":169425,"memory":0.565388360992074},
+  {"account_id":10730,"name":"query:0123/job_id:1876356","created_time":1687221450,"start_time":1687221450,"finished_time":1687221451,"cpu":2,"memory":0.0000028759241104125977},
+  {"account_id":10730,"name":"query:0123/job_id:1920479","created_time":1687221272,"start_time":1687221272,"finished_time":1687221286,"cpu":166208,"memory":0.6223469125106931},
+  {"account_id":10730,"name":"query:0123/job_id:1862812","created_time":1687221298,"start_time":1687221298,"finished_time":1687221301,"cpu":51,"memory":0.000019278377294540405},
+  {"account_id":10730,"name":"query:0123/job_id:1934435","created_time":1687221436,"start_time":1687221437,"finished_time":1687221439,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1932540","created_time":1687221436,"start_time":1687221437,"finished_time":1687221439,"cpu":337,"memory":0.015073344111442566},
+  {"account_id":10730,"name":"query:0123/job_id:1885991","created_time":1687221442,"start_time":1687221442,"finished_time":1687221444,"cpu":13,"memory":8.717179298400879e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1914361","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":31,"memory":0.000002259388566017151},
+  {"account_id":10730,"name":"query:0123/job_id:1937301","created_time":1687219801,"start_time":1687219801,"finished_time":1687219804,"cpu":1,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1941185","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":19,"memory":0.000001817941665649414},
+  {"account_id":10730,"name":"query:0123/job_id:1885158","created_time":1687221490,"start_time":1687221490,"finished_time":1687221521,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1906556","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":167483,"memory":4.3279227670282125},
+  {"account_id":10730,"name":"query:0123/job_id:1951865","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":789177,"memory":14.888746425509453},
+  {"account_id":10730,"name":"query:0123/job_id:1928153","created_time":1687221413,"start_time":1687221413,"finished_time":1687221416,"cpu":15,"memory":0.000001819804310798645},
+  {"account_id":10730,"name":"query:0123/job_id:1872963","created_time":1687221157,"start_time":1687221157,"finished_time":1687221161,"cpu":2110,"memory":0.1509679052978754},
+  {"account_id":10730,"name":"query:0123/job_id:1947016","created_time":1687221595,"start_time":1687221595,"finished_time":1687221781,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1921732","created_time":1687221772,"start_time":1687221772,"finished_time":1687221774,"cpu":126,"memory":0.00031345896422863007},
+  {"account_id":10730,"name":"query:0123/job_id:1931520","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":2009,"memory":0.025191902182996273},
+  {"account_id":10730,"name":"query:0123/job_id:1947298","created_time":1687221595,"start_time":1687221596,"finished_time":1687221604,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1952398","created_time":1687221459,"start_time":1687221459,"finished_time":1687221483,"cpu":529875,"memory":40.296030009165406},
+  {"account_id":10730,"name":"query:0123/job_id:1919612","created_time":1687221459,"start_time":1687221459,"finished_time":1687221483,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1863259","created_time":1687221832,"start_time":1687221832,"finished_time":1687221833,"cpu":6,"memory":0.0000030938535928726196},
+  {"account_id":10730,"name":"query:0123/job_id:1931591","created_time":1687221436,"start_time":1687221436,"finished_time":1687221438,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1878382","created_time":1687221551,"start_time":1687221551,"finished_time":1687221555,"cpu":32162,"memory":0.00627507921308279},
+  {"account_id":10730,"name":"query:0123/job_id:1893028","created_time":1687220671,"start_time":1687220671,"finished_time":1687220679,"cpu":4786,"memory":0.20243860315531492},
+  {"account_id":10730,"name":"query:0123/job_id:1938013","created_time":1687220048,"start_time":1687220048,"finished_time":1687220049,"cpu":98,"memory":0.000004218891263008118},
+  {"account_id":10730,"name":"query:0123/job_id:1930687","created_time":1687219239,"start_time":1687219239,"finished_time":1687219343,"cpu":2368616,"memory":61.78435374144465},
+  {"account_id":10730,"name":"query:0123/job_id:1937070","created_time":1687221311,"start_time":1687221311,"finished_time":1687221313,"cpu":16,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1894249","created_time":1687221259,"start_time":1687221259,"finished_time":1687221272,"cpu":297862,"memory":1.5671367589384317},
+  {"account_id":10730,"name":"query:0123/job_id:1862176","created_time":1687221311,"start_time":1687221311,"finished_time":1687221313,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1878597","created_time":1687221802,"start_time":1687221802,"finished_time":1687221803,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1895733","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":999305,"memory":3.5917544178664684},
+  {"account_id":10730,"name":"query:0123/job_id:1862368","created_time":1687218795,"start_time":1687218795,"finished_time":1687219213,"cpu":31001783,"memory":1562.2868827730417},
+  {"account_id":10730,"name":"query:0123/job_id:1934931","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1944051","created_time":1687221832,"start_time":1687221832,"finished_time":1687221837,"cpu":2,"memory":0.0000022510066628456116},
+  {"account_id":10730,"name":"query:0123/job_id:1856797","created_time":1687219283,"start_time":1687219283,"finished_time":1687219284,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1919389","created_time":1687220915,"start_time":1687220915,"finished_time":1687220922,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879667","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":1587,"memory":0.03553505148738623},
+  {"account_id":10730,"name":"query:0123/job_id:1952779","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":59,"memory":0.0006197383627295494},
+  {"account_id":10730,"name":"query:0123/job_id:1857716","created_time":1687221770,"start_time":1687221770,"finished_time":1687221771,"cpu":3,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1863028","created_time":1687221731,"start_time":1687221731,"finished_time":1687221735,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1915631","created_time":1687220962,"start_time":1687220962,"finished_time":1687220964,"cpu":148,"memory":0.00003062933683395386},
+  {"account_id":10730,"name":"query:0123/job_id:1890204","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1886191","created_time":1687221801,"start_time":1687221801,"finished_time":1687221813,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1934081","created_time":1687220265,"start_time":1687220266,"finished_time":1687220271,"cpu":1450,"memory":0.19393836334347725},
+  {"account_id":10730,"name":"query:0123/job_id:1952354","created_time":1687221366,"start_time":1687221366,"finished_time":1687221389,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1887129","created_time":1687220969,"start_time":1687220969,"finished_time":1687220972,"cpu":142,"memory":0.0003489600494503975},
+  {"account_id":10730,"name":"query:0123/job_id:1895099","created_time":1687222148,"start_time":1687222148,"finished_time":1687222175,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1908424","created_time":1687221551,"start_time":1687221551,"finished_time":1687221554,"cpu":201,"memory":0.003810340538620949},
+  {"account_id":10730,"name":"query:0123/job_id:1854526","created_time":1687221473,"start_time":1687221473,"finished_time":1687221475,"cpu":8,"memory":0.000004100613296031952},
+  {"account_id":10730,"name":"query:0123/job_id:1884732","created_time":1687221278,"start_time":1687221278,"finished_time":1687221281,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1931881","created_time":1687221307,"start_time":1687221307,"finished_time":1687221312,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1887013","created_time":1687221243,"start_time":1687221243,"finished_time":1687221246,"cpu":16,"memory":0.000003050081431865692},
+  {"account_id":10730,"name":"query:0123/job_id:1928755","created_time":1687221298,"start_time":1687221298,"finished_time":1687221305,"cpu":1451,"memory":0.03482540510594845},
+  {"account_id":10730,"name":"query:0123/job_id:1895201","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":1014401,"memory":3.7198743633925915},
+  {"account_id":10730,"name":"query:0123/job_id:1935449","created_time":1687221642,"start_time":1687221642,"finished_time":1687221645,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1927570","created_time":1687221642,"start_time":1687221642,"finished_time":1687221645,"cpu":1058,"memory":0.004289193078875542},
+  {"account_id":10730,"name":"query:0123/job_id:1948220","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1953929","created_time":1687221802,"start_time":1687221802,"finished_time":1687221803,"cpu":8,"memory":0.000004500150680541992},
+  {"account_id":10730,"name":"query:0123/job_id:1896263","created_time":1687221054,"start_time":1687221054,"finished_time":1687221054,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1942657","created_time":1687220165,"start_time":1687220165,"finished_time":1687220165,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1920408","created_time":1687221227,"start_time":1687221227,"finished_time":1687221233,"cpu":2016,"memory":0.052192116156220436},
+  {"account_id":10730,"name":"query:0123/job_id:1918939","created_time":1687221772,"start_time":1687221772,"finished_time":1687221774,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1891522","created_time":1687220388,"start_time":1687220388,"finished_time":1687220390,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1941666","created_time":1687221336,"start_time":1687221336,"finished_time":1687221341,"cpu":11356,"memory":0.4637690931558609},
+  {"account_id":10730,"name":"query:0123/job_id:1941482","created_time":1687221180,"start_time":1687221180,"finished_time":1687221193,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1873799","created_time":1687221300,"start_time":1687221300,"finished_time":1687221317,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1954036","created_time":1687220671,"start_time":1687220671,"finished_time":1687220679,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879778","created_time":1687221586,"start_time":1687221586,"finished_time":1687221686,"cpu":2629412,"memory":14.09130791388452},
+  {"account_id":10730,"name":"query:0123/job_id:1911466","created_time":1687221739,"start_time":1687221739,"finished_time":1687221740,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1922206","created_time":1687221180,"start_time":1687221181,"finished_time":1687221197,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1931864","created_time":1687219764,"start_time":1687219764,"finished_time":1687219937,"cpu":4152084,"memory":231.26982422545552},
+  {"account_id":10730,"name":"query:0123/job_id:1881333","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1895399","created_time":1687221794,"start_time":1687221794,"finished_time":1687221797,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1871964","created_time":1687221722,"start_time":1687221722,"finished_time":1687221724,"cpu":2,"memory":4.731118679046631e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1883348","created_time":1687221726,"start_time":1687221726,"finished_time":1687221746,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1909970","created_time":1687219250,"start_time":1687219250,"finished_time":1687219251,"cpu":5,"memory":0.0000010319054126739502},
+  {"account_id":10730,"name":"query:0123/job_id:1942771","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":9040,"memory":0.5340307019650936},
+  {"account_id":10730,"name":"query:0123/job_id:1873401","created_time":1687219956,"start_time":1687219957,"finished_time":1687220122,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1864331","created_time":1687220932,"start_time":1687220932,"finished_time":1687220940,"cpu":15383,"memory":0.7506414540112019},
+  {"account_id":10730,"name":"query:0123/job_id:1934982","created_time":1687221781,"start_time":1687221781,"finished_time":1687221785,"cpu":35,"memory":0.000004235655069351196},
+  {"account_id":10730,"name":"query:0123/job_id:1882129","created_time":1687221243,"start_time":1687221243,"finished_time":1687221256,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1894840","created_time":1687221570,"start_time":1687221570,"finished_time":1687221571,"cpu":43,"memory":0.000012252479791641235},
+  {"account_id":10730,"name":"query:0123/job_id:1874005","created_time":1687221243,"start_time":1687221243,"finished_time":1687221256,"cpu":171289,"memory":0.6650124043226242},
+  {"account_id":10730,"name":"query:0123/job_id:1862541","created_time":1687222148,"start_time":1687222148,"finished_time":1687222175,"cpu":65102,"memory":0.6362147992476821},
+  {"account_id":10730,"name":"query:0123/job_id:1910345","created_time":1687219819,"start_time":1687219819,"finished_time":1687219822,"cpu":1599,"memory":0.001293383538722992},
+  {"account_id":10730,"name":"query:0123/job_id:1893205","created_time":1687221163,"start_time":1687221163,"finished_time":1687221179,"cpu":252579,"memory":4.632825382053852},
+  {"account_id":10730,"name":"query:0123/job_id:1952873","created_time":1687221445,"start_time":1687221445,"finished_time":1687221450,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1893202","created_time":1687221457,"start_time":1687221457,"finished_time":1687221457,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1922775","created_time":1687221611,"start_time":1687221612,"finished_time":1687221613,"cpu":14,"memory":0.0000016689300537109375},
+  {"account_id":10730,"name":"query:0123/job_id:1893929","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":2046,"memory":0.08831286523491144},
+  {"account_id":10730,"name":"query:0123/job_id:1941961","created_time":1687220287,"start_time":1687220287,"finished_time":1687220317,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1882230","created_time":1687221819,"start_time":1687221819,"finished_time":1687221827,"cpu":88,"memory":0.00024253875017166138},
+  {"account_id":10730,"name":"query:0123/job_id:1905957","created_time":1687221167,"start_time":1687221167,"finished_time":1687221170,"cpu":1061,"memory":0.018153954297304153},
+  {"account_id":10730,"name":"query:0123/job_id:1863291","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1893779","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1949795","created_time":1687221227,"start_time":1687221227,"finished_time":1687221243,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1900140","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1887370","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":55,"memory":0.00032454729080200195},
+  {"account_id":10730,"name":"query:0123/job_id:1941695","created_time":1687221155,"start_time":1687221156,"finished_time":1687221160,"cpu":2411,"memory":0.13838768657296896},
+  {"account_id":10730,"name":"query:0123/job_id:1945390","created_time":1687221801,"start_time":1687221801,"finished_time":1687221813,"cpu":40026,"memory":0.4121660841628909},
+  {"account_id":10730,"name":"query:0123/job_id:1859308","created_time":1687219394,"start_time":1687219395,"finished_time":1687220980,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1927763","created_time":1687219220,"start_time":1687219220,"finished_time":1687219227,"cpu":180,"memory":0.00036745332181453705},
+  {"account_id":10730,"name":"query:0123/job_id:1889368","created_time":1687221276,"start_time":1687221276,"finished_time":1687221286,"cpu":6678,"memory":0.01642802730202675},
+  {"account_id":10730,"name":"query:0123/job_id:1901523","created_time":1687220033,"start_time":1687220033,"finished_time":1687220037,"cpu":138,"memory":0.000020556151866912842},
+  {"account_id":10730,"name":"query:0123/job_id:1943023","created_time":1687221278,"start_time":1687221278,"finished_time":1687221281,"cpu":18,"memory":0.000014452263712882996},
+  {"account_id":10730,"name":"query:0123/job_id:1875845","created_time":1687220221,"start_time":1687220221,"finished_time":1687220262,"cpu":253529,"memory":0.2726001674309373},
+  {"account_id":10730,"name":"query:0123/job_id:1877717","created_time":1687220197,"start_time":1687220198,"finished_time":1687220201,"cpu":1023,"memory":0.051492818631231785},
+  {"account_id":10730,"name":"query:0123/job_id:1912682","created_time":1687222793,"start_time":1687222793,"finished_time":1687222793,"cpu":1,"memory":7.767230272293091e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1878419","created_time":1687220047,"start_time":1687220048,"finished_time":1687220051,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1916463","created_time":1687222497,"start_time":1687222497,"finished_time":1687222511,"cpu":889856,"memory":13.286113446578383},
+  {"account_id":10730,"name":"query:0123/job_id:1945852","created_time":1687220046,"start_time":1687220046,"finished_time":1687220048,"cpu":57,"memory":9.844079613685608e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1912892","created_time":1687220690,"start_time":1687220690,"finished_time":1687220694,"cpu":1051,"memory":0.028402824886143208},
+  {"account_id":10730,"name":"query:0123/job_id:1896902","created_time":1687220729,"start_time":1687220729,"finished_time":1687220741,"cpu":9175,"memory":0.4601225620135665},
+  {"account_id":10730,"name":"query:0123/job_id:1901000","created_time":1687222096,"start_time":1687222096,"finished_time":1687222101,"cpu":42749,"memory":2.3187225153669715},
+  {"account_id":10730,"name":"query:0123/job_id:1915416","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1927160","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1926382","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":1846,"memory":0.03563994821161032},
+  {"account_id":10730,"name":"query:0123/job_id:1897488","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1856751","created_time":1687219605,"start_time":1687219605,"finished_time":1687219609,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1913212","created_time":1687222124,"start_time":1687222125,"finished_time":1687222126,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1903825","created_time":1687221913,"start_time":1687221913,"finished_time":1687221915,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1887001","created_time":1687221913,"start_time":1687221913,"finished_time":1687221915,"cpu":41,"memory":0.0000013373792171478271},
+  {"account_id":10730,"name":"query:0123/job_id:1953145","created_time":1687222124,"start_time":1687222124,"finished_time":1687222126,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1929664","created_time":1687220528,"start_time":1687220529,"finished_time":1687221082,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1866986","created_time":1687219571,"start_time":1687219571,"finished_time":1687219600,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1935460","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":5468,"memory":0.13724800292402506},
+  {"account_id":10730,"name":"query:0123/job_id:1902908","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":1997,"memory":0.05740081053227186},
+  {"account_id":10730,"name":"query:0123/job_id:1879666","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":35,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1867388","created_time":1687221348,"start_time":1687221348,"finished_time":1687221351,"cpu":28,"memory":0.000028837472200393677},
+  {"account_id":10730,"name":"query:0123/job_id:1928237","created_time":1687219498,"start_time":1687219498,"finished_time":1687219509,"cpu":1724,"memory":0.0018572863191366196},
+  {"account_id":10730,"name":"query:0123/job_id:1859711","created_time":1687221383,"start_time":1687221383,"finished_time":1687221388,"cpu":1741,"memory":0.0024359971284866333},
+  {"account_id":10730,"name":"query:0123/job_id:1884609","created_time":1687221818,"start_time":1687221818,"finished_time":1687221958,"cpu":154679,"memory":5.28403483517468},
+  {"account_id":10730,"name":"query:0123/job_id:1870086","created_time":1687222261,"start_time":1687222261,"finished_time":1687222281,"cpu":137348,"memory":6.620400631800294},
+  {"account_id":10730,"name":"query:0123/job_id:1945737","created_time":1687221896,"start_time":1687221896,"finished_time":1687221897,"cpu":31,"memory":0.00004255864769220352},
+  {"account_id":10730,"name":"query:0123/job_id:1909344","created_time":1687220526,"start_time":1687220526,"finished_time":1687220654,"cpu":6278421,"memory":82.99605563655496},
+  {"account_id":10730,"name":"query:0123/job_id:1901760","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":8868,"memory":0.48437179904431105},
+  {"account_id":10730,"name":"query:0123/job_id:1887962","created_time":1687222248,"start_time":1687222248,"finished_time":1687222264,"cpu":25366,"memory":0.0007336661219596863},
+  {"account_id":10730,"name":"query:0123/job_id:1866695","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":27,"memory":9.08970832824707e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1867486","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1936848","created_time":1687220063,"start_time":1687220063,"finished_time":1687220069,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1936567","created_time":1687220079,"start_time":1687220079,"finished_time":1687220080,"cpu":4,"memory":2.60770320892334e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1860651","created_time":1687219491,"start_time":1687219491,"finished_time":1687219493,"cpu":4,"memory":2.5331974029541016e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1936743","created_time":1687220059,"start_time":1687220059,"finished_time":1687220070,"cpu":84057,"memory":0.581495494581759},
+  {"account_id":10730,"name":"query:0123/job_id:1873799","created_time":1687220059,"start_time":1687220059,"finished_time":1687220070,"cpu":29,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1889854","created_time":1687222516,"start_time":1687222516,"finished_time":1687222530,"cpu":1349213,"memory":25.21270072646439},
+  {"account_id":10730,"name":"query:0123/job_id:1909449","created_time":1687222272,"start_time":1687222272,"finished_time":1687222275,"cpu":47,"memory":4.544854164123535e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1858455","created_time":1687222036,"start_time":1687222036,"finished_time":1687222040,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1869922","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":34,"memory":0.00014067348092794418},
+  {"account_id":10730,"name":"query:0123/job_id:1923240","created_time":1687221366,"start_time":1687221366,"finished_time":1687221389,"cpu":173155,"memory":0.6662634816020727},
+  {"account_id":10730,"name":"query:0123/job_id:1878433","created_time":1687220063,"start_time":1687220064,"finished_time":1687220066,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1918956","created_time":1687219798,"start_time":1687219798,"finished_time":1687219802,"cpu":1775,"memory":0.0013281740248203278},
+  {"account_id":10730,"name":"query:0123/job_id:1873160","created_time":1687222279,"start_time":1687222279,"finished_time":1687222512,"cpu":1475072,"memory":29.879191937856376},
+  {"account_id":10730,"name":"query:0123/job_id:1867885","created_time":1687222095,"start_time":1687222095,"finished_time":1687222099,"cpu":274,"memory":0.00003236904740333557},
+  {"account_id":10730,"name":"query:0123/job_id:1945687","created_time":1687222069,"start_time":1687222069,"finished_time":1687222071,"cpu":133,"memory":0.00003302004188299179},
+  {"account_id":10730,"name":"query:0123/job_id:1899200","created_time":1687222128,"start_time":1687222128,"finished_time":1687222138,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1903354","created_time":1687222229,"start_time":1687222230,"finished_time":1687222234,"cpu":14475,"memory":0.8644355805590749},
+  {"account_id":10730,"name":"query:0123/job_id:1875296","created_time":1687221328,"start_time":1687221328,"finished_time":1687221334,"cpu":1871,"memory":0.02522611990571022},
+  {"account_id":10730,"name":"query:0123/job_id:1927102","created_time":1687220065,"start_time":1687220065,"finished_time":1687220070,"cpu":2620,"memory":0.0894061429426074},
+  {"account_id":10730,"name":"query:0123/job_id:1913690","created_time":1687220065,"start_time":1687220065,"finished_time":1687220070,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1925529","created_time":1687221300,"start_time":1687221300,"finished_time":1687221317,"cpu":171333,"memory":0.6323725860565901},
+  {"account_id":10730,"name":"query:0123/job_id:1945868","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":32,"memory":0.0000024242326617240906},
+  {"account_id":10730,"name":"query:0123/job_id:1854845","created_time":1687222260,"start_time":1687222260,"finished_time":1687224138,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1890633","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":26,"memory":3.4086406230926514e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1910966","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":60,"memory":0.0005310773849487305},
+  {"account_id":10730,"name":"query:0123/job_id:1953345","created_time":1687220065,"start_time":1687220065,"finished_time":1687220139,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1944770","created_time":1687221419,"start_time":1687221419,"finished_time":1687221422,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1860300","created_time":1687220058,"start_time":1687220058,"finished_time":1687220059,"cpu":33,"memory":0.0000020060688257217407},
+  {"account_id":10730,"name":"query:0123/job_id:1854308","created_time":1687220045,"start_time":1687220045,"finished_time":1687220049,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1917073","created_time":1687221423,"start_time":1687221423,"finished_time":1687221428,"cpu":33,"memory":0.000001912936568260193},
+  {"account_id":10730,"name":"query:0123/job_id:1874552","created_time":1687222495,"start_time":1687222495,"finished_time":1687222496,"cpu":55,"memory":0.00005161110311746597},
+  {"account_id":10730,"name":"query:0123/job_id:1874115","created_time":1687222233,"start_time":1687222234,"finished_time":1687222238,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1906357","created_time":1687221871,"start_time":1687221871,"finished_time":1687221912,"cpu":1413226,"memory":0.030194759368896484},
+  {"account_id":10730,"name":"query:0123/job_id:1929412","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":30,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1877755","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":8,"memory":5.112960934638977e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1937715","created_time":1687222532,"start_time":1687222532,"finished_time":1687222563,"cpu":877663,"memory":37.235547291114926},
+  {"account_id":10730,"name":"query:0123/job_id:1896383","created_time":1687220700,"start_time":1687220700,"finished_time":1687220711,"cpu":9166,"memory":0.40832468774169683},
+  {"account_id":10730,"name":"query:0123/job_id:1892286","created_time":1687222088,"start_time":1687222088,"finished_time":1687222092,"cpu":147,"memory":0.0038497494533658028},
+  {"account_id":10730,"name":"query:0123/job_id:1865696","created_time":1687219626,"start_time":1687219627,"finished_time":1687219628,"cpu":0,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1888402","created_time":1687221400,"start_time":1687221401,"finished_time":1687221420,"cpu":214993,"memory":7.887006695382297},
+  {"account_id":10730,"name":"query:0123/job_id:1912452","created_time":1687220047,"start_time":1687220048,"finished_time":1687220051,"cpu":4269,"memory":0.11234669387340546},
+  {"account_id":10730,"name":"query:0123/job_id:1938477","created_time":1687222003,"start_time":1687222003,"finished_time":1687222005,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1865402","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1952310","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":5800,"memory":0.0347793772816658},
+  {"account_id":10730,"name":"query:0123/job_id:1938893","created_time":1687220915,"start_time":1687220915,"finished_time":1687220922,"cpu":2609,"memory":0.28729093074798584},
+  {"account_id":10730,"name":"query:0123/job_id:1877272","created_time":1687221389,"start_time":1687221389,"finished_time":1687221396,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1915604","created_time":1687221490,"start_time":1687221490,"finished_time":1687221521,"cpu":45384,"memory":0.9703322276473045},
+  {"account_id":10730,"name":"query:0123/job_id:1878331","created_time":1687219538,"start_time":1687219538,"finished_time":1687219540,"cpu":3,"memory":2.812594175338745e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1903504","created_time":1687222030,"start_time":1687222030,"finished_time":1687222034,"cpu":14,"memory":0.000007779337465763092},
+  {"account_id":10730,"name":"query:0123/job_id:1935890","created_time":1687222242,"start_time":1687222242,"finished_time":1687222257,"cpu":69911,"memory":4.9587449841201305},
+  {"account_id":10730,"name":"query:0123/job_id:1882046","created_time":1687221595,"start_time":1687221596,"finished_time":1687221604,"cpu":1202,"memory":0.12898958288133144},
+  {"account_id":10730,"name":"query:0123/job_id:1864005","created_time":1687221919,"start_time":1687221919,"finished_time":1687221921,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1937951","created_time":1687221357,"start_time":1687221358,"finished_time":1687221360,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1949694","created_time":1687222330,"start_time":1687222330,"finished_time":1687222331,"cpu":25,"memory":0.0005985591560602188},
+  {"account_id":10730,"name":"query:0123/job_id:1924263","created_time":1687219956,"start_time":1687219957,"finished_time":1687220122,"cpu":4701057,"memory":277.56208450719714},
+  {"account_id":10730,"name":"query:0123/job_id:1916975","created_time":1687221964,"start_time":1687221964,"finished_time":1687221964,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1940384","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":52,"memory":0.00014798343181610107},
+  {"account_id":10730,"name":"query:0123/job_id:1856979","created_time":1687219645,"start_time":1687219646,"finished_time":1687219652,"cpu":1762,"memory":0.0014302656054496765},
+  {"account_id":10730,"name":"query:0123/job_id:1870846","created_time":1687221936,"start_time":1687221936,"finished_time":1687221938,"cpu":0,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1906933","created_time":1687219765,"start_time":1687219765,"finished_time":1687219767,"cpu":1,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1874309","created_time":1687222104,"start_time":1687222104,"finished_time":1687222121,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1933610","created_time":1687219687,"start_time":1687219687,"finished_time":1687219696,"cpu":12523,"memory":0.29332683701068163},
+  {"account_id":10730,"name":"query:0123/job_id:1904123","created_time":1687219687,"start_time":1687219687,"finished_time":1687219696,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1857757","created_time":1687222095,"start_time":1687222095,"finished_time":1687222099,"cpu":699,"memory":0.000017278827726840973},
+  {"account_id":10730,"name":"query:0123/job_id:1947773","created_time":1687222063,"start_time":1687222063,"finished_time":1687222072,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1885116","created_time":1687222108,"start_time":1687222108,"finished_time":1687222154,"cpu":1724822,"memory":122.43716402724385},
+  {"account_id":10730,"name":"query:0123/job_id:1935071","created_time":1687221365,"start_time":1687221365,"finished_time":1687221367,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1878799","created_time":1687222107,"start_time":1687222107,"finished_time":1687222120,"cpu":211059,"memory":11.376393739134073},
+  {"account_id":10730,"name":"query:0123/job_id:1941097","created_time":1687219441,"start_time":1687219441,"finished_time":1687219446,"cpu":144,"memory":0.000029970891773700714},
+  {"account_id":10730,"name":"query:0123/job_id:1862051","created_time":1687219688,"start_time":1687219688,"finished_time":1687219730,"cpu":528966,"memory":6.334656901657581},
+  {"account_id":10730,"name":"query:0123/job_id:1914382","created_time":1687222056,"start_time":1687222056,"finished_time":1687222095,"cpu":995100,"memory":32.03270216938108},
+  {"account_id":10730,"name":"query:0123/job_id:1875788","created_time":1687219507,"start_time":1687219507,"finished_time":1687219513,"cpu":8,"memory":3.4086406230926514e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1941847","created_time":1687222124,"start_time":1687222125,"finished_time":1687222126,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1863240","created_time":1687220700,"start_time":1687220700,"finished_time":1687220711,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1910737","created_time":1687220065,"start_time":1687220065,"finished_time":1687220083,"cpu":238857,"memory":0.27852213103324175},
+  {"account_id":10730,"name":"query:0123/job_id:1915625","created_time":1687221362,"start_time":1687221362,"finished_time":1687221380,"cpu":1384,"memory":0.034782237373292446},
+  {"account_id":10730,"name":"query:0123/job_id:1887339","created_time":1687219571,"start_time":1687219571,"finished_time":1687219600,"cpu":275253,"memory":3.5219838758930564},
+  {"account_id":10730,"name":"query:0123/job_id:1903586","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":753,"memory":0.005912870168685913},
+  {"account_id":10730,"name":"query:0123/job_id:1882752","created_time":1687220072,"start_time":1687220072,"finished_time":1687220073,"cpu":4,"memory":3.818422555923462e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1923327","created_time":1687219721,"start_time":1687219721,"finished_time":1687219722,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1865356","created_time":1687219687,"start_time":1687219687,"finished_time":1687219688,"cpu":3,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1883618","created_time":1687219764,"start_time":1687219764,"finished_time":1687219937,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1876943","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":35,"memory":6.975606083869934e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1891564","created_time":1687221936,"start_time":1687221936,"finished_time":1687221938,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1884446","created_time":1687219663,"start_time":1687219663,"finished_time":1687219672,"cpu":36963,"memory":0.1375558190047741},
+  {"account_id":10730,"name":"query:0123/job_id:1943959","created_time":1687220047,"start_time":1687220047,"finished_time":1687220049,"cpu":26,"memory":8.437782526016235e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1887252","created_time":1687221403,"start_time":1687221403,"finished_time":1687221408,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1882584","created_time":1687222196,"start_time":1687222196,"finished_time":1687222203,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1926303","created_time":1687222104,"start_time":1687222104,"finished_time":1687222121,"cpu":88601,"memory":3.038497334346175},
+  {"account_id":10730,"name":"query:0123/job_id:1913824","created_time":1687221919,"start_time":1687221919,"finished_time":1687221969,"cpu":85583,"memory":1.6815164554864168},
+  {"account_id":10730,"name":"query:0123/job_id:1859247","created_time":1687221389,"start_time":1687221389,"finished_time":1687221396,"cpu":15,"memory":0.000003471970558166504},
+  {"account_id":10730,"name":"query:0123/job_id:1889364","created_time":1687219366,"start_time":1687219366,"finished_time":1687219539,"cpu":3227336,"memory":186.95616215001792},
+  {"account_id":10730,"name":"query:0123/job_id:1941061","created_time":1687219511,"start_time":1687219511,"finished_time":1687219522,"cpu":40,"memory":0.00010661780834197998},
+  {"account_id":10730,"name":"query:0123/job_id:1880772","created_time":1687219511,"start_time":1687219511,"finished_time":1687219522,"cpu":0,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1922530","created_time":1687222063,"start_time":1687222063,"finished_time":1687222072,"cpu":66642,"memory":7.241031132638454},
+  {"account_id":10730,"name":"query:0123/job_id:1928114","created_time":1687222272,"start_time":1687222272,"finished_time":1687222275,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1936782","created_time":1687221373,"start_time":1687221373,"finished_time":1687221393,"cpu":27,"memory":5.112960934638977e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1937360","created_time":1687220719,"start_time":1687220720,"finished_time":1687220724,"cpu":1508,"memory":0.055711349472403526},
+  {"account_id":10730,"name":"query:0123/job_id:1953784","created_time":1687222017,"start_time":1687222017,"finished_time":1687222025,"cpu":152,"memory":0.02313260082155466},
+  {"account_id":10730,"name":"query:0123/job_id:1940844","created_time":1687222108,"start_time":1687222108,"finished_time":1687222154,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1925233","created_time":1687219728,"start_time":1687219728,"finished_time":1687219730,"cpu":4,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1938438","created_time":1687219619,"start_time":1687219619,"finished_time":1687219662,"cpu":337463,"memory":7.5993646727874875},
+  {"account_id":10730,"name":"query:0123/job_id:1898320","created_time":1687219619,"start_time":1687219619,"finished_time":1687219662,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1869160","created_time":1687222078,"start_time":1687222079,"finished_time":1687222101,"cpu":385234,"memory":18.12602466996759},
+  {"account_id":10730,"name":"query:0123/job_id:1858876","created_time":1687219425,"start_time":1687219425,"finished_time":1687219436,"cpu":672,"memory":0.000019224360585212708},
+  {"account_id":10730,"name":"query:0123/job_id:1858376","created_time":1687222229,"start_time":1687222230,"finished_time":1687222234,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1937240","created_time":1687221894,"start_time":1687221894,"finished_time":1687221895,"cpu":24,"memory":0.00005719717592000961},
+  {"account_id":10730,"name":"query:0123/job_id:1864616","created_time":1687221988,"start_time":1687221988,"finished_time":1687221989,"cpu":2,"memory":4.7124922275543213e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1940461","created_time":1687219688,"start_time":1687219688,"finished_time":1687219730,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1880316","created_time":1687220519,"start_time":1687220519,"finished_time":1687220521,"cpu":1796,"memory":0.028349141590297222},
+  {"account_id":10730,"name":"query:0123/job_id:1873646","created_time":1687220729,"start_time":1687220729,"finished_time":1687220741,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1856989","created_time":1687222190,"start_time":1687222190,"finished_time":1687222194,"cpu":1042,"memory":0.15664026141166687},
+  {"account_id":10730,"name":"query:0123/job_id:1898817","created_time":1687221911,"start_time":1687221911,"finished_time":1687221913,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1872651","created_time":1687219690,"start_time":1687219690,"finished_time":1687219694,"cpu":132,"memory":0.00002968963235616684},
+  {"account_id":10730,"name":"query:0123/job_id:1887504","created_time":1687219478,"start_time":1687219478,"finished_time":1687219482,"cpu":40,"memory":0.00011587142944335938},
+  {"account_id":10730,"name":"query:0123/job_id:1914521","created_time":1687222050,"start_time":1687222050,"finished_time":1687222051,"cpu":1,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1869944","created_time":1687221919,"start_time":1687221919,"finished_time":1687221921,"cpu":0,"memory":2.2724270820617676e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1915351","created_time":1687220621,"start_time":1687220621,"finished_time":1687220623,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1913246","created_time":1687221922,"start_time":1687221922,"finished_time":1687221923,"cpu":20,"memory":0.00005175638943910599},
+  {"account_id":10730,"name":"query:0123/job_id:1858277","created_time":1687222471,"start_time":1687222471,"finished_time":1687222476,"cpu":197767,"memory":0.1941282246261835},
+  {"account_id":10730,"name":"query:0123/job_id:1941474","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1858285","created_time":1687222070,"start_time":1687222070,"finished_time":1687222072,"cpu":63,"memory":0.0001813843846321106},
+  {"account_id":10730,"name":"query:0123/job_id:1929738","created_time":1687221927,"start_time":1687221928,"finished_time":1687221929,"cpu":1,"memory":1.7043203115463257e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1922442","created_time":1687222182,"start_time":1687222182,"finished_time":1687222192,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1890458","created_time":1687220046,"start_time":1687220046,"finished_time":1687220049,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1936446","created_time":1687220046,"start_time":1687220046,"finished_time":1687220049,"cpu":425,"memory":0.015547140501439571},
+  {"account_id":10730,"name":"query:0123/job_id:1928174","created_time":1687222088,"start_time":1687222088,"finished_time":1687222092,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1947301","created_time":1687222279,"start_time":1687222279,"finished_time":1687222280,"cpu":1,"memory":0.00001825764775276184},
+  {"account_id":10730,"name":"query:0123/job_id:1888759","created_time":1687220063,"start_time":1687220063,"finished_time":1687220069,"cpu":1678,"memory":0.050700913183391094},
+  {"account_id":10730,"name":"query:0123/job_id:1861676","created_time":1687222124,"start_time":1687222124,"finished_time":1687222128,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1863973","created_time":1687222196,"start_time":1687222196,"finished_time":1687222203,"cpu":76052,"memory":1.4273631423711777},
+  {"account_id":10730,"name":"query:0123/job_id:1913657","created_time":1687221403,"start_time":1687221403,"finished_time":1687221408,"cpu":11396,"memory":0.462107015773654},
+  {"account_id":10730,"name":"query:0123/job_id:1876712","created_time":1687219446,"start_time":1687219447,"finished_time":1687219449,"cpu":2,"memory":5.941838026046753e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1920207","created_time":1687219765,"start_time":1687219765,"finished_time":1687219767,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1917638","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":2477,"memory":0.19905488658696413},
+  {"account_id":10730,"name":"query:0123/job_id:1938804","created_time":1687222198,"start_time":1687222199,"finished_time":1687222203,"cpu":8732,"memory":0.12800941988825798},
+  {"account_id":10730,"name":"query:0123/job_id:1868195","created_time":1687222224,"start_time":1687222224,"finished_time":1687222228,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1904594","created_time":1687219562,"start_time":1687219562,"finished_time":1687219562,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1942652","created_time":1687219713,"start_time":1687219713,"finished_time":1687219716,"cpu":133,"memory":0.0003508310765028},
+  {"account_id":10730,"name":"query:0123/job_id:1923138","created_time":1687220033,"start_time":1687220033,"finished_time":1687220037,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1925388","created_time":1687222209,"start_time":1687222209,"finished_time":1687222222,"cpu":147907,"memory":3.05915738735348},
+  {"account_id":10730,"name":"query:0123/job_id:1920452","created_time":1687222209,"start_time":1687222209,"finished_time":1687222222,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1864086","created_time":1687222480,"start_time":1687222480,"finished_time":1687222495,"cpu":863380,"memory":27.77284919284284},
+  {"account_id":10730,"name":"query:0123/job_id:1892514","created_time":1687222242,"start_time":1687222242,"finished_time":1687222257,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1948150","created_time":1687221336,"start_time":1687221336,"finished_time":1687221341,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1889033","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879781","created_time":1687221903,"start_time":1687221903,"finished_time":1687221906,"cpu":76,"memory":0.016456210985779762},
+  {"account_id":10730,"name":"query:0123/job_id:1913073","created_time":1687221323,"start_time":1687221323,"finished_time":1687221328,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1880113","created_time":1687222248,"start_time":1687222248,"finished_time":1687222251,"cpu":18,"memory":0.0000034086406230926514},
+  {"account_id":10730,"name":"query:0123/job_id:1906863","created_time":1687220969,"start_time":1687220969,"finished_time":1687220972,"cpu":161,"memory":0.00003048870712518692},
+  {"account_id":10730,"name":"query:0123/job_id:1888950","created_time":1687221067,"start_time":1687221067,"finished_time":1687221067,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1945541","created_time":1687222260,"start_time":1687222260,"finished_time":1687222265,"cpu":12682,"memory":0.5331832701340318},
+  {"account_id":10730,"name":"query:0123/job_id:1938116","created_time":1687222096,"start_time":1687222096,"finished_time":1687222101,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1867683","created_time":1687221398,"start_time":1687221399,"finished_time":1687221405,"cpu":1831,"memory":0.034573921002447605},
+  {"account_id":10730,"name":"query:0123/job_id:1950331","created_time":1687221468,"start_time":1687221468,"finished_time":1687221469,"cpu":1,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1918267","created_time":1687222247,"start_time":1687222247,"finished_time":1687222263,"cpu":24938,"memory":0.00017203297466039658},
+  {"account_id":10730,"name":"query:0123/job_id:1891576","created_time":1687220528,"start_time":1687220529,"finished_time":1687221082,"cpu":11871969,"memory":1635.820930318907},
+  {"account_id":10730,"name":"query:0123/job_id:1936057","created_time":1687221460,"start_time":1687221460,"finished_time":1687221466,"cpu":37261,"memory":0.045606739819049835},
+  {"account_id":10730,"name":"query:0123/job_id:1888334","created_time":1687221403,"start_time":1687221403,"finished_time":1687221409,"cpu":31,"memory":0.00010038726031780243},
+  {"account_id":10730,"name":"query:0123/job_id:1925524","created_time":1687222554,"start_time":1687222554,"finished_time":1687222556,"cpu":4,"memory":3.259629011154175e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1938038","created_time":1687221414,"start_time":1687221414,"finished_time":1687221426,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1928078","created_time":1687221435,"start_time":1687221435,"finished_time":1687221446,"cpu":8164,"memory":0.017148369923233986},
+  {"account_id":10730,"name":"query:0123/job_id:1929945","created_time":1687219394,"start_time":1687219395,"finished_time":1687220980,"cpu":198996631,"memory":4.554481757804751},
+  {"account_id":10730,"name":"query:0123/job_id:1952857","created_time":1687220063,"start_time":1687220064,"finished_time":1687220066,"cpu":305,"memory":0.014173568226397038},
+  {"account_id":10730,"name":"query:0123/job_id:1908775","created_time":1687221678,"start_time":1687221678,"finished_time":1687221690,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1950404","created_time":1687222198,"start_time":1687222199,"finished_time":1687222203,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1879996","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":16,"memory":0.0000034086406230926514},
+  {"account_id":10730,"name":"query:0123/job_id:1949944","created_time":1687219974,"start_time":1687219974,"finished_time":1687220008,"cpu":0,"memory":1.7043203115463257e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1874780","created_time":1687221652,"start_time":1687221652,"finished_time":1687221663,"cpu":142393,"memory":0.3617932302877307},
+  {"account_id":10730,"name":"query:0123/job_id:1946424","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1923353","created_time":1687221396,"start_time":1687221396,"finished_time":1687221398,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1942691","created_time":1687221495,"start_time":1687221496,"finished_time":1687221556,"cpu":410525,"memory":0.5270743481814861},
+  {"account_id":10730,"name":"query:0123/job_id:1869694","created_time":1687221137,"start_time":1687221137,"finished_time":1687221139,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1953982","created_time":1687221450,"start_time":1687221450,"finished_time":1687221454,"cpu":1692,"memory":0.002086389809846878},
+  {"account_id":10730,"name":"query:0123/job_id:1921234","created_time":1687221054,"start_time":1687221054,"finished_time":1687221054,"cpu":0,"memory":1.4808028936386108e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1943725","created_time":1687221402,"start_time":1687221402,"finished_time":1687221414,"cpu":123659,"memory":7.229120437987149},
+  {"account_id":10730,"name":"query:0123/job_id:1947001","created_time":1687221487,"start_time":1687221488,"finished_time":1687221488,"cpu":0,"memory":1.778826117515564e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1859772","created_time":1687221357,"start_time":1687221358,"finished_time":1687221360,"cpu":407,"memory":0.0025974735617637634},
+  {"account_id":10730,"name":"query:0123/job_id:1855966","created_time":1687221146,"start_time":1687221146,"finished_time":1687221147,"cpu":2,"memory":2.8312206268310547e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1902996","created_time":1687220959,"start_time":1687220959,"finished_time":1687220962,"cpu":155,"memory":0.00001742597669363022},
+  {"account_id":10730,"name":"query:0123/job_id:1901548","created_time":1687220156,"start_time":1687220156,"finished_time":1687220314,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1909353","created_time":1687221476,"start_time":1687221476,"finished_time":1687221485,"cpu":12879,"memory":0.18855485878884792},
+  {"account_id":10730,"name":"query:0123/job_id:1946665","created_time":1687221579,"start_time":1687221579,"finished_time":1687221585,"cpu":26,"memory":6.817281246185303e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1894696","created_time":1687222247,"start_time":1687222247,"finished_time":1687222250,"cpu":12623,"memory":0.0005376730114221573},
+  {"account_id":10730,"name":"query:0123/job_id:1857301","created_time":1687221157,"start_time":1687221157,"finished_time":1687221161,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1866817","created_time":1687220064,"start_time":1687220064,"finished_time":1687220096,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1918831","created_time":1687222210,"start_time":1687222210,"finished_time":1687222218,"cpu":22694,"memory":0.3896253043785691},
+  {"account_id":10730,"name":"query:0123/job_id:1917594","created_time":1687222045,"start_time":1687222045,"finished_time":1687222052,"cpu":62,"memory":0.0006200522184371948},
+  {"account_id":10730,"name":"query:0123/job_id:1875286","created_time":1687221395,"start_time":1687221395,"finished_time":1687221397,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1878054","created_time":1687220516,"start_time":1687220516,"finished_time":1687220517,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1878933","created_time":1687221659,"start_time":1687221659,"finished_time":1687221673,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1872495","created_time":1687221659,"start_time":1687221659,"finished_time":1687221673,"cpu":59367,"memory":2.1684274496510625},
+  {"account_id":10730,"name":"query:0123/job_id:1919112","created_time":1687222378,"start_time":1687222378,"finished_time":1687222379,"cpu":178,"memory":0.0037594372406601906},
+  {"account_id":10730,"name":"query:0123/job_id:1891430","created_time":1687221445,"start_time":1687221445,"finished_time":1687221450,"cpu":8412,"memory":0.3779042772948742},
+  {"account_id":10730,"name":"query:0123/job_id:1868488","created_time":1687221743,"start_time":1687221743,"finished_time":1687221745,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1931802","created_time":1687221743,"start_time":1687221743,"finished_time":1687221745,"cpu":19,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1944697","created_time":1687221817,"start_time":1687221817,"finished_time":1687221818,"cpu":0,"memory":1.685693860054016e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1933522","created_time":1687221167,"start_time":1687221167,"finished_time":1687221170,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1884559","created_time":1687221690,"start_time":1687221690,"finished_time":1687221696,"cpu":1500,"memory":0.03479896765202284},
+  {"account_id":10730,"name":"query:0123/job_id:1911045","created_time":1687221819,"start_time":1687221819,"finished_time":1687221827,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1919996","created_time":1687221988,"start_time":1687221988,"finished_time":1687221990,"cpu":2,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1889649","created_time":1687221564,"start_time":1687221564,"finished_time":1687221565,"cpu":29,"memory":0.000036937184631824493},
+  {"account_id":10730,"name":"query:0123/job_id:1923256","created_time":1687221547,"start_time":1687221547,"finished_time":1687221548,"cpu":9,"memory":0.000005221925675868988},
+  {"account_id":10730,"name":"query:0123/job_id:1899625","created_time":1687220932,"start_time":1687220932,"finished_time":1687220940,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1928598","created_time":1687221460,"start_time":1687221460,"finished_time":1687221462,"cpu":5,"memory":7.031485438346863e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1938084","created_time":1687221848,"start_time":1687221848,"finished_time":1687221853,"cpu":1837,"memory":0.0042940182611346245},
+  {"account_id":10730,"name":"query:0123/job_id:1876258","created_time":1687221163,"start_time":1687221163,"finished_time":1687221179,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1910167","created_time":1687221474,"start_time":1687221474,"finished_time":1687221527,"cpu":1444850,"memory":0.017147465609014034},
+  {"account_id":10730,"name":"query:0123/job_id:1954326","created_time":1687221731,"start_time":1687221731,"finished_time":1687221735,"cpu":2541,"memory":0.07881707511842251},
+  {"account_id":10730,"name":"query:0123/job_id:1925064","created_time":1687221053,"start_time":1687221053,"finished_time":1687221054,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1903701","created_time":1687221338,"start_time":1687221338,"finished_time":1687221352,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1926984","created_time":1687222592,"start_time":1687222592,"finished_time":1687222594,"cpu":1,"memory":1.4062970876693726e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1887053","created_time":1687221620,"start_time":1687221620,"finished_time":1687221621,"cpu":0,"memory":2.598389983177185e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1866475","created_time":1687221065,"start_time":1687221065,"finished_time":1687221065,"cpu":0,"memory":2.896413207054138e-7},
+  {"account_id":10730,"name":"query:0123/job_id:1902305","created_time":1687219840,"start_time":1687219840,"finished_time":1687220117,"cpu":6755107,"memory":668.3046566024423},
+  {"account_id":10730,"name":"query:0123/job_id:1905411","created_time":1687222329,"start_time":1687222329,"finished_time":1687222339,"cpu":24433,"memory":0.002141670323908329},
+  {"account_id":10730,"name":"query:0123/job_id:1869286","created_time":1687220065,"start_time":1687220065,"finished_time":1687220083,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1867250","created_time":1687218886,"start_time":1687218886,"finished_time":1687221999,"cpu":12709733,"memory":2779.913918171078},
+  {"account_id":10730,"name":"query:0123/job_id:1871280","created_time":1687221432,"start_time":1687221432,"finished_time":1687221436,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1887946","created_time":1687221394,"start_time":1687221394,"finished_time":1687221396,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1951346","created_time":1687220690,"start_time":1687220690,"finished_time":1687220694,"cpu":0,"memory":0.0},
+  {"account_id":10730,"name":"query:0123/job_id:1900912","created_time":1687222022,"start_time":1687222022,"finished_time":1687222031,"cpu":1715,"memory":0.06944573298096657}
+]

--- a/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
+++ b/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
@@ -50,10 +50,6 @@ object CapacitySimulator extends LogSupport:
           (totalMemoryTime + job.memoryTime <= capacity.maxMemoryTime)
       )
 
-    var count = 0;
-
-    def wakeupJobs(): Unit = {}
-
     /**
       * Sweep all of the jobs from the queues preceding the given sweepLimit
       * @param sweepLimit

--- a/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
+++ b/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
@@ -83,7 +83,6 @@ object CapacitySimulator extends LogSupport:
 
     // Sort intervals first in order to sweep the jobs from left to right
     val sortedInputJobs = jobs.sortBy(_.created_time)
-    debug(s"Input list: \t${sortedInputJobs.size}")
     for (j <- sortedInputJobs) {
       sweepUntil(j.start)
       // If the queue has more slots for jobs
@@ -104,6 +103,4 @@ object CapacitySimulator extends LogSupport:
     }
     sweepUntil(Long.MaxValue)
     // Return the simulation result
-    debug(s"Waiting Queue: \t${waitingQueue.size}")
-    debug(s"Schedule list: \t${simulatedJobs.result().size}")
     CapacitySimulatorReport(simulatedJobs.result(), capacity)

--- a/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
+++ b/src/main/scala/wvlet/querybase/interval/CapacitySimulator.scala
@@ -43,11 +43,16 @@ object CapacitySimulator extends LogSupport:
     def totalMemoryTime = runningQueue.map(_.memoryTime).sum
 
     def hasSufficientCapacityFor(job: A): Boolean =
-      (runningQueue.size + 1 <= capacity.maxConcurrentJobs) &&
-        (totalCPUTime + job.cpuTime <= capacity.maxCpuTime) &&
-        (totalMemoryTime + job.memoryTime <= capacity.maxMemoryTime)
+      // If no query is running, we can start the job regardless of the cluster capacity
+      runningQueue.isEmpty || (
+        (runningQueue.size + 1 <= capacity.maxConcurrentJobs) &&
+          (totalCPUTime + job.cpuTime <= capacity.maxCpuTime) &&
+          (totalMemoryTime + job.memoryTime <= capacity.maxMemoryTime)
+      )
 
     var count = 0;
+
+    def wakeupJobs(): Unit = {}
 
     /**
       * Sweep all of the jobs from the queues preceding the given sweepLimit

--- a/src/main/scala/wvlet/querybase/interval/IntervalLike.scala
+++ b/src/main/scala/wvlet/querybase/interval/IntervalLike.scala
@@ -9,7 +9,7 @@ trait IntervalLike[A]:
     def updateWith(created_time: Long, start_time: Long, finished_time: Long): A
     def end: Long
     def cpuTime: Long
-    def memoryTime: Long
+    def memoryTime: Double
     def length: Long                                   = end - start
     def contains[B: IntervalLike](other: B): Boolean   = a.start <= other.start && other.end <= a.end
     def contains(pos: Long): Boolean                   = a.start <= pos && pos < a.end

--- a/src/main/scala/wvlet/querybase/interval/JobInterval.scala
+++ b/src/main/scala/wvlet/querybase/interval/JobInterval.scala
@@ -15,7 +15,7 @@ case class JobInterval(
     finished_time: Long,
     sig: String,
     cpu: Long,
-    memory: Long
+    memory: Double
 ) {}
 
 object JobInterval extends LogSupport {
@@ -31,7 +31,7 @@ object JobInterval extends LogSupport {
       def start_time: Long    = j.start_time
       def finished_time: Long = j.finished_time
       def cpuTime: Long       = j.cpu
-      def memoryTime: Long    = j.memory
+      def memoryTime: Double  = j.memory
       def updateWith(created_time: Long, start_time: Long, finished_time: Long): JobInterval =
         j.copy(created_time = created_time, start_time = start_time, finished_time = finished_time)
 
@@ -46,9 +46,13 @@ object JobInterval extends LogSupport {
   def loadFromParquet(parquetFilePath: String): Seq[JobInterval] = {
     Class.forName("org.duckdb.DuckDBDriver")
     val lst = Seq.newBuilder[JobInterval]
-    Using(DriverManager.getConnection("jdbc:duckdb:")) { conn =>
-      Using(conn.createStatement()) { stmt =>
-        Using(stmt.executeQuery(s"select * from '${parquetFilePath}'")) { rs =>
+    Using.resource(DriverManager.getConnection("jdbc:duckdb:")) { conn =>
+      Using.resource(conn.createStatement()) { stmt =>
+        Using.resource(
+          stmt.executeQuery(
+            s"select name, created_time, start_time, finished_time, 'N/A' as sig, cpu, memory from '${parquetFilePath}'"
+          )
+        ) { rs =>
           while (rs.next()) {
             lst += JobInterval(
               name = rs.getString(1),
@@ -57,7 +61,7 @@ object JobInterval extends LogSupport {
               finished_time = rs.getLong(4),
               sig = rs.getString(5),
               cpu = rs.getLong(6),
-              memory = rs.getLong(7)
+              memory = rs.getDouble(7)
             )
           }
         }

--- a/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
+++ b/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
@@ -17,8 +17,12 @@ class CapacitySimulatorTest extends AirSpec {
     )
     debug(result)
     result shouldBe CapacitySimulator.CapacitySimulatorReport(
-      List(JobInterval("job 1",1,1,8,"n/a",20,20), JobInterval("job 2",2,8,9,"n/a",50,50)),
+      List(JobInterval("job 1", 1, 1, 8, "n/a", 20, 20), JobInterval("job 2", 2, 8, 9, "n/a", 50, 50)),
       capacity
     )
+  }
+
+  test("simulate 579 jobs") {
+    val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
   }
 }

--- a/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
+++ b/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
@@ -23,6 +23,18 @@ class CapacitySimulatorTest extends AirSpec {
   }
 
   test("simulate 579 jobs") {
-    val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
+    val jobs     = JobInterval.loadFromParquet("data/jobs_579.parquet")
+    val capacity = CapacitySimulator.ClusterCapacity(1, 100000, 1000000000)
+    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
+      jobs = jobs,
+      capacity = capacity
+    )
+    val totalQueuedTime = result.simulatedJobs.map(j => j.start_time - j.created_time).sum
+    // Get the 95-tile of queued time
+    val queuedTime95 = result.simulatedJobs
+      .map(j => j.start_time - j.created_time).sorted.apply((result.simulatedJobs.size * 0.95).toInt)
+
+    // debug(result)
+    info(s"total queued time: ${totalQueuedTime}, p95: ${queuedTime95}")
   }
 }

--- a/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
+++ b/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
@@ -4,23 +4,23 @@ import wvlet.airspec.AirSpec
 import wvlet.querybase.interval.{CapacitySimulator, JobInterval}
 
 class CapacitySimulatorTest extends AirSpec {
-  test("simulateJobSchedule") {
-    val sortedIntervals = Seq(
-      JobInterval("job 1", 1, 3, 10, "n/a", 20, 20),
-      JobInterval("job 2", 2, 2, 3, "n/a", 50, 50)
-    )
-      .sortBy(_.created_time)
-    val capacity = CapacitySimulator.ClusterCapacity(1, 1000000, 1000000)
-    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
-      jobs = sortedIntervals,
-      capacity = capacity
-    )
-    debug(result)
-    result shouldBe CapacitySimulator.CapacitySimulatorReport(
-      List(JobInterval("job 1", 1, 1, 8, "n/a", 20, 20), JobInterval("job 2", 2, 8, 9, "n/a", 50, 50)),
-      capacity
-    )
-  }
+//  test("simulateJobSchedule") {
+//    val sortedIntervals = Seq(
+//      JobInterval("job 1", 1, 3, 10, "n/a", 20, 20),
+//      JobInterval("job 2", 2, 2, 3, "n/a", 50, 50)
+//    )
+//      .sortBy(_.created_time)
+//    val capacity = CapacitySimulator.ClusterCapacity(1, 1000000, 1000000)
+//    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
+//      jobs = sortedIntervals,
+//      capacity = capacity
+//    )
+//    debug(result)
+//    result shouldBe CapacitySimulator.CapacitySimulatorReport(
+//      List(JobInterval("job 1", 1, 1, 8, "n/a", 20, 20), JobInterval("job 2", 2, 8, 9, "n/a", 50, 50)),
+//      capacity
+//    )
+//  }
 
   test("simulate 579 jobs") {
     val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
@@ -36,8 +36,26 @@ class CapacitySimulatorTest extends AirSpec {
       val queuedTime95 = result.simulatedJobs
         .map(j => j.start_time - j.created_time).sorted.apply((result.simulatedJobs.size * 0.95).toInt)
 
-      // debug(result)
-      info(s"capacity: ${capacity}, total queued time: ${totalQueuedTime}, p95: ${queuedTime95}")
+      info(s"Jobs: ${capacity.maxConcurrentJobs}\tCPU: ${capacity.maxCpuTime}\tMem: ${capacity.maxMemoryTime}\tTime: ${totalQueuedTime}\tp95: ${queuedTime95}")
+      val num = result.simulatedJobs.size.asInstanceOf[Double]
+      val avgCPU = result.simulatedJobs.map(j => j.cpuTime).sum / num;
+      val avgMem = result.simulatedJobs.map(j => j.memoryTime).sum / num;
+      val avgTime = totalQueuedTime / num;
+      info(s"Number of jobs: ${num.asInstanceOf[Int]}\nAvg CPU: ${avgCPU}\nAvg Mem: ${avgMem}\nAvg Time: ${avgTime}\nTotal Time: ${totalQueuedTime}")
     }
   }
+//
+//  test("find average of jobs") {
+//    val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
+//    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
+//      jobs = jobs,
+//      capacity = CapacitySimulator.ClusterCapacity(1, 1, 1)
+//    )
+//    val num = result.simulatedJobs.size.asInstanceOf[Double]
+//    val avgCPU = result.simulatedJobs.map(j => j.cpuTime).sum / num;
+//    val avgMem = result.simulatedJobs.map(j => j.memoryTime).sum / num;
+//    val totalQueuedTime = result.simulatedJobs.map(j => j.start_time - j.created_time).sum;
+//    val avgTime = totalQueuedTime / num;
+//    info(s"Number of jobs: ${num.asInstanceOf[Int]}\nAvg CPU: ${avgCPU}\nAvg Mem: ${avgMem}\nAvg Time: ${avgTime}\nTotal Time: ${totalQueuedTime}")
+//  }
 }

--- a/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
+++ b/src/test/scala/wvlet/querybase/interval/CapacitySimulatorTest.scala
@@ -4,29 +4,28 @@ import wvlet.airspec.AirSpec
 import wvlet.querybase.interval.{CapacitySimulator, JobInterval}
 
 class CapacitySimulatorTest extends AirSpec {
-//  test("simulateJobSchedule") {
-//    val sortedIntervals = Seq(
-//      JobInterval("job 1", 1, 3, 10, "n/a", 20, 20),
-//      JobInterval("job 2", 2, 2, 3, "n/a", 50, 50)
-//    )
-//      .sortBy(_.created_time)
-//    val capacity = CapacitySimulator.ClusterCapacity(1, 1000000, 1000000)
-//    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
-//      jobs = sortedIntervals,
-//      capacity = capacity
-//    )
-//    debug(result)
-//    result shouldBe CapacitySimulator.CapacitySimulatorReport(
-//      List(JobInterval("job 1", 1, 1, 8, "n/a", 20, 20), JobInterval("job 2", 2, 8, 9, "n/a", 50, 50)),
-//      capacity
-//    )
-//  }
+  test("simulateJobSchedule") {
+    val sortedIntervals = Seq(
+      JobInterval("job 1", 1, 3, 10, "n/a", 20, 20),
+      JobInterval("job 2", 2, 2, 3, "n/a", 50, 50)
+    )
+      .sortBy(_.created_time)
+    val capacity = CapacitySimulator.ClusterCapacity(1, 1000000, 1000000)
+    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
+      jobs = sortedIntervals,
+      capacity = capacity
+    )
+    debug(result)
+    result shouldBe CapacitySimulator.CapacitySimulatorReport(
+      List(JobInterval("job 1", 1, 1, 8, "n/a", 20, 20), JobInterval("job 2", 2, 8, 9, "n/a", 50, 50)),
+      capacity
+    )
+  }
 
   test("simulate 579 jobs") {
     val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
-
-    for (maxConcurrentJobs <- Seq(1, 10, 100); memory <- Seq(2, 4, 8, 16)) {
-      val capacity = CapacitySimulator.ClusterCapacity(maxConcurrentJobs, 100000, memory)
+    for (maxConcurrentJobs <- Seq(1, 10, 100); cpu <- Seq(70000, 700000, 7000000); memory <- Seq(2, 4, 8, 16)) {
+      val capacity = CapacitySimulator.ClusterCapacity(maxConcurrentJobs, cpu, memory)
       val result = CapacitySimulator.simulateJobSchedule[JobInterval](
         jobs = jobs,
         capacity = capacity
@@ -37,25 +36,18 @@ class CapacitySimulatorTest extends AirSpec {
         .map(j => j.start_time - j.created_time).sorted.apply((result.simulatedJobs.size * 0.95).toInt)
 
       info(s"Jobs: ${capacity.maxConcurrentJobs}\tCPU: ${capacity.maxCpuTime}\tMem: ${capacity.maxMemoryTime}\tTime: ${totalQueuedTime}\tp95: ${queuedTime95}")
-      val num = result.simulatedJobs.size.asInstanceOf[Double]
-      val avgCPU = result.simulatedJobs.map(j => j.cpuTime).sum / num;
-      val avgMem = result.simulatedJobs.map(j => j.memoryTime).sum / num;
-      val avgTime = totalQueuedTime / num;
-      info(s"Number of jobs: ${num.asInstanceOf[Int]}\nAvg CPU: ${avgCPU}\nAvg Mem: ${avgMem}\nAvg Time: ${avgTime}\nTotal Time: ${totalQueuedTime}")
     }
   }
-//
-//  test("find average of jobs") {
-//    val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
-//    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
-//      jobs = jobs,
-//      capacity = CapacitySimulator.ClusterCapacity(1, 1, 1)
-//    )
-//    val num = result.simulatedJobs.size.asInstanceOf[Double]
-//    val avgCPU = result.simulatedJobs.map(j => j.cpuTime).sum / num;
-//    val avgMem = result.simulatedJobs.map(j => j.memoryTime).sum / num;
-//    val totalQueuedTime = result.simulatedJobs.map(j => j.start_time - j.created_time).sum;
-//    val avgTime = totalQueuedTime / num;
-//    info(s"Number of jobs: ${num.asInstanceOf[Int]}\nAvg CPU: ${avgCPU}\nAvg Mem: ${avgMem}\nAvg Time: ${avgTime}\nTotal Time: ${totalQueuedTime}")
-//  }
+
+  test("find average of jobs") {
+    val jobs = JobInterval.loadFromParquet("data/jobs_579.parquet")
+    val result = CapacitySimulator.simulateJobSchedule[JobInterval](
+      jobs = jobs,
+      capacity = CapacitySimulator.ClusterCapacity(1, 1, 1)
+    )
+    val num = result.simulatedJobs.size.asInstanceOf[Double]
+    val avgCPU = result.simulatedJobs.map(j => j.cpuTime).sum / num;
+    val avgMem = result.simulatedJobs.map(j => j.memoryTime).sum / num;
+    info(s"Number of jobs: ${num.asInstanceOf[Int]}\nAvg CPU: ${avgCPU}\nAvg Mem: ${avgMem}")
+  }
 }

--- a/src/test/scala/wvlet/querybase/interval/JobIntervalTest.scala
+++ b/src/test/scala/wvlet/querybase/interval/JobIntervalTest.scala
@@ -18,7 +18,7 @@ class JobIntervalTest extends AirSpec:
   test("read Parquet file") {
     val lst = JobInterval.loadFromParquet("data/sample_jobs.parquet")
     lst shouldBe List(
-      JobInterval("job 1", 100, 120, 200, "n/a", 200000, 200000),
-      JobInterval("job 2", 110, 130, 150, "n/a", 500000, 500000)
+      JobInterval("job 1", 100, 120, 200, "N/A", 200000, 200000),
+      JobInterval("job 2", 110, 130, 150, "N/A", 500000, 500000)
     )
   }


### PR DESCRIPTION
Fixed a bug in job simulation when the job resource usage exceeds the cluster capacity from the beginning.